### PR TITLE
fix(frontend): ビルドハッシュをgitコミットハッシュに変更

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,12 +3,17 @@ import vue from '@vitejs/plugin-vue'
 import tailwindcss from '@tailwindcss/vite'
 import { fileURLToPath, URL } from 'node:url'
 
-import crypto from 'node:crypto'
+import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 
-// ビルドごとにユニークなハッシュを生成
-const buildHash = crypto.randomBytes(8).toString('hex')
+// gitコミットハッシュを取得（どのコミットがデプロイされたか特定するため）
+let buildHash = 'unknown'
+try {
+  buildHash = execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim()
+} catch {
+  // git未使用環境（CI等）のフォールバック
+}
 
 // ビルドハッシュをファイルに保存（CDKが読み込む）
 function writeBuildHashPlugin() {


### PR DESCRIPTION
## 概要
フッターのビルドハッシュをランダム値からgitコミットハッシュに変更。
デプロイされた画面がどのコミットに対応するか特定可能にする。

## 変更内容
- `frontend/vite.config.js`: `crypto.randomBytes()` → `git rev-parse --short HEAD`
- 変更前: `v3.1.1 (aba7279b1d649be1)` ← ランダム値
- 変更後: `v3.1.1 (00ca64f)` ← gitコミットハッシュ

## テスト
- [x] E2Eテスト 21/21 passed
- [x] フロントエンドビルド成功
- [x] デプロイ・画面確認済み

## 関連Issue
Issue #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)