### PR TITLE
fix(deploy): deploy-frontendがダミーLayerでImageProcessorApiStackを上書きする問題を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -179,12 +179,16 @@ jobs:
       - name: TypeScript build
         run: npm run build
 
-      - name: Create dummy ffmpeg layer
-        run: |
-          mkdir -p lambda-layers
-          if [ ! -f lambda-layers/ffmpeg-layer.zip ]; then
-            echo "dummy" | zip lambda-layers/ffmpeg-layer.zip -
-          fi
+      - name: Cache ffmpeg layer
+        id: ffmpeg-cache
+        uses: actions/cache@v4
+        with:
+          path: lambda-layers/ffmpeg-layer.zip
+          key: ffmpeg-layer-amd64-static-v4.4.2
+
+      - name: Build ffmpeg Lambda layer
+        if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
+        run: bash scripts/create-ffmpeg-layer.sh
 
       - name: Generate config.json
         run: |


### PR DESCRIPTION
## 概要

PR #30 の FFmpeg layer 修正後も video-generation テストが失敗していた原因を調査した結果、**deploy-frontend ジョブがダミー Layer (202バイト) を作成**していることが判明。

## 根本原因

\`cdk deploy FrontendStack\` は依存スタック (ImageProcessorApiStack) も処理するため、deploy-frontend が作成したダミー \`lambda-layers/ffmpeg-layer.zip\` で **FfmpegLayer が上書きデプロイ**されていた。

タイムライン (今回の dev push 結果):
1. 14:42 deploy-backend が実Layer (57MB) ビルド
2. 14:43 deploy-backend の \`cdk deploy ImageProcessorApiStack\` で FfmpegLayer v7 (実バイナリ) が作成
3. 14:44 deploy-frontend が **ダミーLayer (202B)** を作成
4. 14:46 deploy-frontend の \`cdk deploy FrontendStack\` 内で ImageProcessorApiStack も依存解決で再デプロイ → **FfmpegLayer v8 (ダミー)** で置き換え

確認:
- S3 asset (CDKがアップロード): \`7babc64...zip\` 57MB ✓ 実バイナリ
- 実際のLambda Layer (v8): 202バイト, 中身は dummy (echo "dummy" | zip 結果)

## 修正内容

deploy-frontend ジョブの \`Create dummy ffmpeg layer\` ステップを deploy-backend と同じ \`Cache + Build\` 構成に置換。

\`\`\`yaml
- name: Cache ffmpeg layer
  id: ffmpeg-cache
  uses: actions/cache@v4
  with:
    path: lambda-layers/ffmpeg-layer.zip
    key: ffmpeg-layer-amd64-static-v4.4.2

- name: Build ffmpeg Lambda layer
  if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
  run: bash scripts/create-ffmpeg-layer.sh
\`\`\`

deploy-backend と同じ cache key を使用するため、deploy-frontend では **cache hit で即座に復元**（再ダウンロード不要）。

## Test plan

- [ ] PRマージ後、dev → CD パイプラインが起動
- [ ] deploy-backend で実Layer ビルド or キャッシュ復元
- [ ] deploy-frontend でも実Layer 復元（cache hit想定）
- [ ] デプロイ後 e2e-test の \`video-generation.api.spec.ts\` 3件パス
- [ ] AWS Lambda Layer の CodeSize が 202バイトでなく ~57MB になっていること

## 関連

- Refs #29
- Follows #30 (Phase 1 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)