### PR TITLE
test(api): video-generation アサーションを実APIレスポンスに合わせて修正

### DIFF
--- a/test/e2e/video-generation.api.spec.ts
+++ b/test/e2e/video-generation.api.spec.ts
@@ -63,7 +63,9 @@ test.describe('動画生成機能のAPIテスト', () => {
     })
 
     expect(validResponse.status()).toBe(200)
-    expect(validResponse.headers()['content-type']).toMatch(/video\/|application\/octet-stream/)
+    // APIはS3にアップロードした動画URLをJSONで返す（image_processor.py:617-638）
+    // application/json (URL返却) または video/* / octet-stream (バイナリ直接返却) を許容
+    expect(validResponse.headers()['content-type']).toMatch(/video\/|application\/octet-stream|application\/json/)
 
     // 無効な動画長さのテスト
     console.log('❌ 無効な動画長さのテスト')
@@ -341,7 +343,8 @@ test.describe('動画生成機能のAPIテスト', () => {
     })
 
     // 無効な画像ソースでもエラーハンドリングされることを確認
-    expect([400, 500]).toContain(invalidImageResponse.status())
+    // APIは無効画像時に404を返す（リソース未発見扱い）。400(クライアントエラー)/500(サーバーエラー)も許容
+    expect([400, 404, 500]).toContain(invalidImageResponse.status())
 
     // 極端に長い動画のテスト
     console.log('❌ 極端に長い動画のテスト')


### PR DESCRIPTION
## 概要

PR #31 の FFmpeg layer 修正で video-generation が**実際に動作するようになった結果**、テスト側の期待値と実 API レスポンス仕様の不一致が2件露呈したため修正。

## 修正内容

### 1. 動画生成成功時の Content-Type (line 66)

API は S3 にアップロードした動画の URL を JSON で返す設計（\`image_processor.py:617-638\`）。

\`\`\`diff
- expect(validResponse.headers()['content-type']).toMatch(/video\/|application\/octet-stream/)
+ expect(validResponse.headers()['content-type']).toMatch(/video\/|application\/octet-stream|application\/json/)
\`\`\`

### 2. 無効画像時のステータスコード (line 344)

API は無効な画像ソース時に **404** を返す。テストは 400/500 のみ許容していたため失敗。

\`\`\`diff
- expect([400, 500]).toContain(invalidImageResponse.status())
+ expect([400, 404, 500]).toContain(invalidImageResponse.status())
\`\`\`

## 検証 (staging環境)

ローカルから staging API に対して実行:

| テストファイル | 結果 |
|--------------|------|
| \`image-processor.api.spec.ts\` | ✅ 8/8 全パス |
| \`video-generation.api.spec.ts\` | ✅ 6/6 全パス（前回 4/6 から完全パス） |

合計 **14/14 全パス**

## 関連

- Refs #29
- Follows #31 (FFmpeg layer fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)