### PR TITLE
fix(agent): AgentFunction (ARM_64) の pip install に aarch64 platform 指定追加 (#33)

### DIFF
--- a/lib/image-processor-api-stack.ts
+++ b/lib/image-processor-api-stack.ts
@@ -622,7 +622,10 @@ export class ImageProcessorApiStack extends cdk.Stack {
               'echo "Starting Agent Lambda bundling..."',
               'pip install --upgrade pip',
               // Agent専用依存のみインストール（opentelemetry-sdk含む、strands-agentsが依存）
-              'pip install strands-agents anthropic pillow boto3 opentelemetry-sdk opentelemetry-api opentelemetry-exporter-otlp-proto-http -t /asset-output --no-cache-dir 2>&1 | tail -5',
+              // Lambda は ARM_64 アーキで動作するため、aarch64 ホイールを明示指定
+              // （指定なしだと bundling Docker のホスト arch = x86_64 ホイールが入り、
+              //  Pillow 等の C 拡張が ImportError になる）
+              'pip install strands-agents anthropic pillow boto3 opentelemetry-sdk opentelemetry-api opentelemetry-exporter-otlp-proto-http -t /asset-output --no-cache-dir --platform manylinux2014_aarch64 --only-binary=:all: 2>&1 | tail -5',
               'cp *.py /asset-output/',
               'if [ -d images ]; then cp -r images /asset-output/; fi',
               'if [ -d fonts ]; then cp -r fonts /asset-output/; fi',


### PR DESCRIPTION
## 概要

Chat Agent API テスト 19件全件 500 エラーの根本原因を修正。

## 根本原因

AgentFunction Lambda は \`ARM_64\` アーキで動作するが、bundling Docker (x86_64ホスト) 上の \`pip install\` で \`--platform\` 指定がなかったため、**x86_64 用 Pillow ホイール**がインストールされていた。結果、ARM_64 Lambda 上で \`_imaging\` C 拡張ロードが失敗:

\`\`\`
ImportError: cannot import name '_imaging' from 'PIL' (/var/task/PIL/__init__.py)
  File "/var/task/agent_tools.py", line 27, in <module>
      from PIL import Image
\`\`\`

CWLogs (\`/aws/lambda/agent-handler-function-staging\`) で確認。

## 修正

\`lib/image-processor-api-stack.ts:625\` の AgentFunction bundling pip install に \`--platform manylinux2014_aarch64 --only-binary=:all:\` を追加。

\`\`\`diff
- pip install strands-agents anthropic pillow boto3 ... -t /asset-output --no-cache-dir
+ pip install strands-agents anthropic pillow boto3 ... -t /asset-output --no-cache-dir \\
+   --platform manylinux2014_aarch64 --only-binary=:all:
\`\`\`

ImageProcessorFunction (X86_64) は同様のオプションで \`manylinux2014_x86_64\` を指定済み (line 107) で問題なし。本修正で AgentFunction も整合。

## 検証

| 項目 | 結果 |
|------|------|
| aarch64 wheel 全パッケージ取得 (61個) | ✅ 全成功（pillow, cffi, pydantic_core, jiter, rpds_py 等のC拡張含む） |
| TypeScript build | ✅ |
| CDK synth | ⏭ CI で検証（Pi 環境では Docker bundling 不可） |
| chat-agent.api.spec.ts 19件 | マージ後の CD/e2e で確認 |

## 関連

- Closes #33
- Refs #29 (Phase 2)
- 親PR: #30, #31, #32 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)