### PR TITLE
fix(deploy): CLOUDFRONT_DOMAIN を staging 環境の Lambda にも確実に設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -224,12 +224,15 @@ jobs:
           CF_DOMAIN=$(aws cloudformation describe-stacks --stack-name "$FRONT_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" --output text 2>/dev/null || echo "")
           if [ -n "$CF_DOMAIN" ]; then
-            for FUNC_NAME in $(aws lambda list-functions \
-              --query "Functions[?starts_with(FunctionName, '${API_STACK}-ImageProcessor') || starts_with(FunctionName, '${API_STACK}-AgentFunction')].FunctionName" \
+            # Lambda 関数名は 64 字制限で切り捨てられるため (例: 'Staging' → 'Stagi')、
+            # CFN スタックリソースから物理 ID を直接取得する（名前切り捨て耐性）
+            for FUNC_NAME in $(aws cloudformation list-stack-resources --stack-name "$API_STACK" \
+              --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function' && (contains(LogicalResourceId, 'ImageProcessor') || contains(LogicalResourceId, 'AgentFunction'))].PhysicalResourceId" \
               --output text); do
               CURRENT_ENV=$(aws lambda get-function-configuration --function-name "$FUNC_NAME" --query "Environment.Variables" --output json)
               UPDATED_ENV=$(echo "$CURRENT_ENV" | python3 -c "import sys,json; d=json.load(sys.stdin); d['CLOUDFRONT_DOMAIN']='${CF_DOMAIN}'; print(json.dumps({'Variables':d}))")
               aws lambda update-function-configuration --function-name "$FUNC_NAME" --environment "$UPDATED_ENV" --no-cli-pager > /dev/null
+              echo "Updated $FUNC_NAME"
             done
             echo "CLOUDFRONT_DOMAIN updated to ${CF_DOMAIN}"
           fi

--- a/test/e2e/integration-e2e.api.spec.ts
+++ b/test/e2e/integration-e2e.api.spec.ts
@@ -60,8 +60,11 @@ test.describe('統合機能E2Eテスト', () => {
     // Step 3: 画像一覧で確認
     console.log('📋 Step 3: 画像一覧確認');
     
+    // maxKeys=10 だとアップロード済み画像数 > 10 のとき新規ファイルが
+    // S3 key (UUID) のアルファベット順ページングで漏れて find が undefined → flaky
+    // 上限の 1000 まで取得して確実にヒットさせる
     const listResponse = await request.get(`${UPLOAD_API_URL}/images`, {
-      params: { maxKeys: '10' }
+      params: { maxKeys: '1000' }
     });
 
     expect(listResponse.status()).toBe(200);


### PR DESCRIPTION
## 概要

PR #34 (Pillow ARM64 修正) で chat-agent 18/19 件パスするようになったが、残る 1 件 (\`A1: 2画像合成でCloudFront画像URLが返ること\`) が \`CLOUDFRONT_DOMAIN\` 未設定により S3 presigned URL を返して失敗していた問題を修正。

## 根本原因

Lambda 関数名は 64 文字制限で切り捨てられる:

| 環境 | 期待される名前 | 実際の名前 |
|------|--------------|----------|
| production | \`ImageProcessorApiStack-AgentFunction...\` | そのまま |
| staging | \`ImageProcessorApiStack-Staging-AgentFunction...\` | **\`ImageProcessorApiStack-Stagi-AgentFunction...\`** (\`Staging\` → \`Stagi\`) |

\`deploy.yml\` の \`Update Lambda CLOUDFRONT_DOMAIN\` ステップが \`starts_with(FunctionName, '\${API_STACK}-...')\` で検索していたため、staging 環境では **0 件マッチ** → \`CLOUDFRONT_DOMAIN\` が Lambda に設定されない。

結果、Agent / ImageProcessor が CloudFront URL を生成できず S3 presigned URL にフォールバック (\`agent_tools.py:230\`, \`image_processor.py:605\`)。

## 修正

\`aws lambda list-functions\` の名前検索から、CFN スタックリソースの \`PhysicalResourceId\` 取得に変更。\`LogicalResourceId\` で対象を絞り込むため名前切り捨ての影響を受けない。

\`\`\`diff
- for FUNC_NAME in $(aws lambda list-functions \\
-   --query "Functions[?starts_with(FunctionName, '\${API_STACK}-ImageProcessor') || starts_with(FunctionName, '\${API_STACK}-AgentFunction')].FunctionName" \\
-   --output text); do
+ for FUNC_NAME in $(aws cloudformation list-stack-resources --stack-name "\$API_STACK" \\
+   --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function' && (contains(LogicalResourceId, 'ImageProcessor') || contains(LogicalResourceId, 'AgentFunction'))].PhysicalResourceId" \\
+   --output text); do
\`\`\`

## 検証

- 新クエリで staging Lambda 2 件 (AgentFunction, ImageProcessorFunction) 正しく取得
- 手動で staging Lambda に \`CLOUDFRONT_DOMAIN\` 設定後、ローカルから staging API に対して \`chat-agent.api.spec.ts\` 実行: **29/29 全件パス**

## 関連

- Refs #29
- Sub-issue #33 (Phase 2)
- Follows PR #34 (Pillow ARM64 修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)