### PR TITLE
test(api): 動画長さテストを JSON size フィールド参照に修正 (#33 連鎖修正)

### DIFF
--- a/test/e2e/video-generation.api.spec.ts
+++ b/test/e2e/video-generation.api.spec.ts
@@ -217,18 +217,17 @@ test.describe('動画生成機能のAPIテスト', () => {
 
         expect(response.status()).toBe(200)
 
-        const videoData = await response.body()
-        const fileSize = videoData.length
+        // APIはS3にアップロードした動画URLをJSONで返す（image_processor.py:617-638）
+        // 動画サイズは JSON の size フィールドを参照（response.body() の長さは JSON 自体のサイズ）
+        const body = await response.json()
+        const videoSize = body.size ?? 0
 
-        console.log(`   ファイルサイズ: ${(fileSize / 1024).toFixed(1)} KB`)
+        console.log(`   動画サイズ: ${(videoSize / 1024).toFixed(1)} KB`)
         console.log(`   処理時間: ${processingTime}ms`)
 
-        // 動画の長さに応じてファイルサイズが変化することを確認
-        // （厳密な検証は困難だが、極端に小さくないことを確認）
-        expect(fileSize).toBeGreaterThan(duration * 100) // 秒あたり最低100バイト
-
-        // 処理時間が動画の長さに比例することを確認
-        expect(processingTime).toBeGreaterThan(duration * 1000) // 秒あたり最低1秒の処理時間
+        // 動画ファイルが生成されていることを確認（極端に小さくない）
+        // ffmpeg で生成された MP4 は 1秒動画でも数KB以上になる
+        expect(videoSize).toBeGreaterThan(duration * 1000) // 秒あたり最低1KB
 
         console.log(`✅ ${duration}秒動画の生成が成功`)
 


### PR DESCRIPTION
## 概要

PR #35 マージ後の CD で 1件残った video-generation テスト失敗を修正。連鎖的影響:

- PR #35 で CLOUDFRONT_DOMAIN が staging Lambda に正しく設定された
- 動画生成 API のレスポンス JSON 内の URL が **S3 presigned URL (~1700B)** から **CloudFront URL (~200B)** へ短縮
- 結果、JSON 全体のバイト数が小さくなり、既存の \`fileSize > duration * 100\` アサーションが失敗

## 失敗内容

\`\`\`
Expected: > 300
Received: 291
test/e2e/video-generation.api.spec.ts:228
expect(fileSize).toBeGreaterThan(duration * 100)
\`\`\`

\`fileSize\` は \`response.body().length\` で取得していたが、これは JSON 文字列のバイト数 (約 290B) であり、実動画ファイルサイズではない。

## 修正

- \`response.body()\` の長さ → \`response.json().size\` (動画実サイズ、ffmpeg 生成 MP4 は数KB以上)
- 閾値を \`> duration * 100\` → \`> duration * 1000\` に強化
- 不安定な \`processingTime > duration * 1000\` のアサーション削除

## 検証

ローカルから staging API に対して \`video-generation.api.spec.ts\` 全件パス (6/6)。

## 関連

- Refs #29
- Sub-issue #33 (Phase 2)
- Follows PR #34 (Pillow ARM64), PR #35 (CLOUDFRONT_DOMAIN + integration-e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)