### PR TITLE
fix(api): baseOpacity 非数値入力時にデフォルト100へフォールバック (#37)

### DIFF
--- a/lambda/python/image_processor.py
+++ b/lambda/python/image_processor.py
@@ -450,7 +450,10 @@ def handler(event, context):
         image2_param = query_params.get('image2')
         image3_param = query_params.get('image3')  # オプション
         base_image_param = query_params.get('baseImage')
-        base_opacity_param = int(query_params.get('baseOpacity', '100'))
+        try:
+            base_opacity_param = int(query_params.get('baseOpacity', '100'))
+        except (ValueError, TypeError):
+            base_opacity_param = 100  # 非数値はデフォルトにフォールバック (Issue #37)
         base_opacity_param = max(0, min(100, base_opacity_param))  # 0-100にクランプ
         format_param = query_params.get('format', 'png')
 

--- a/test/lambda/test_image_processor.py
+++ b/test/lambda/test_image_processor.py
@@ -128,5 +128,31 @@ class TestImageProcessor(unittest.TestCase):
         body = json.loads(result['body'])
         self.assertIn('error', body)
 
+    @patch('image_processor.fetch_images_parallel')
+    @patch('image_processor.create_composite_image')
+    def test_handler_non_numeric_base_opacity_falls_back_to_default(
+        self, mock_create_composite, mock_fetch_parallel
+    ):
+        """baseOpacityに非数値が渡された場合、500にせずデフォルト100にフォールバックする (Issue #37)"""
+        mock_fetch_parallel.return_value = {'image1': self.test_image}
+        mock_create_composite.return_value = self.test_image
+
+        event = {
+            'queryStringParameters': {
+                'baseImage': 'test',
+                'image1': 'test',
+                'baseOpacity': 'abc',
+                'format': 'png',
+            }
+        }
+
+        result = image_processor.handler(event, {})
+
+        self.assertEqual(result['statusCode'], 200)
+        # create_composite_image が base_opacity=100（デフォルト）で呼ばれていること
+        _, kwargs = mock_create_composite.call_args
+        self.assertEqual(kwargs.get('base_opacity'), 100)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- `GET /images/composite` の `baseOpacity` パラメータに非数値（例: `baseOpacity=abc`）が渡された際、`int()` の `ValueError` が伝搬して 500 エラーになる問題を修正
- `try/except` でデフォルト値 100 にフォールバック後、既存の 0-100 クランプを通す
- 既存の数値入力時の挙動には影響なし

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `lambda/python/image_processor.py` | `baseOpacity` の `int()` を try/except で保護 |
| `test/lambda/test_image_processor.py` | 非数値入力で 200 を返しデフォルト 100 が使われることを検証するテスト追加 |

## Test plan
- [x] 新規ユニットテスト追加: `test_handler_non_numeric_base_opacity_falls_back_to_default`
- [x] 全 207 件パス（206 → +1）
- [ ] CI（push 後自動）
- [ ] staging e2e（dev マージ後自動）

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)