### PR TITLE
fix(agent): generate_video の invoke_params を camelCase へ揃える (#41)

### DIFF
--- a/lambda/python/agent_tools.py
+++ b/lambda/python/agent_tools.py
@@ -381,13 +381,14 @@ def generate_video(
     sz1 = _resolve_size(image1_size)
 
     # ImageProcessor Lambdaにパラメータを組み立て
+    # キー名は image_processor.parse_image_parameters が期待する camelCase に揃える (Issue #41)
     invoke_params = {
         'image1': image1,
-        'image1_x': str(pos1[0]),
-        'image1_y': str(pos1[1]),
-        'image1_width': str(sz1[0]),
-        'image1_height': str(sz1[1]),
-        'base_image': base_image,
+        'image1X': str(pos1[0]),
+        'image1Y': str(pos1[1]),
+        'image1Width': str(sz1[0]),
+        'image1Height': str(sz1[1]),
+        'baseImage': base_image,
         'baseOpacity': str(max(0, min(100, base_opacity))),
         'format': 'png',
         'generate_video': 'true',
@@ -400,10 +401,10 @@ def generate_video(
         sz2 = _resolve_size(image2_size)
         invoke_params.update({
             'image2': image2,
-            'image2_x': str(pos2[0]),
-            'image2_y': str(pos2[1]),
-            'image2_width': str(sz2[0]),
-            'image2_height': str(sz2[1]),
+            'image2X': str(pos2[0]),
+            'image2Y': str(pos2[1]),
+            'image2Width': str(sz2[0]),
+            'image2Height': str(sz2[1]),
         })
 
     if image3:
@@ -411,10 +412,10 @@ def generate_video(
         sz3 = _resolve_size(image3_size)
         invoke_params.update({
             'image3': image3,
-            'image3_x': str(pos3[0]),
-            'image3_y': str(pos3[1]),
-            'image3_width': str(sz3[0]),
-            'image3_height': str(sz3[1]),
+            'image3X': str(pos3[0]),
+            'image3Y': str(pos3[1]),
+            'image3Width': str(sz3[0]),
+            'image3Height': str(sz3[1]),
         })
 
     # テキストパラメータをinvoke_paramsに追加

--- a/test/lambda/test_agent_tools.py
+++ b/test/lambda/test_agent_tools.py
@@ -7,6 +7,7 @@ Agent Tools のユニットテスト
 - _format_size ヘルパー
 """
 
+import json
 import unittest
 import os
 import sys
@@ -19,7 +20,13 @@ from agent_prompts import resolve_position, resolve_size, POSITION_MAP, DEFAULT_
 
 # PILがない環境でもテスト可能にする
 with patch.dict('sys.modules', {'PIL': MagicMock(), 'PIL.Image': MagicMock()}):
-    from agent_tools import get_help, _format_size
+    import agent_tools
+    from agent_tools import get_help, _format_size, generate_video
+
+# patch.dict はブロック終了時に sys.modules を復元してしまい、import した
+# agent_tools が消えるため、後段の mock.patch('agent_tools.X') が解決できない。
+# 明示的に再登録する。
+sys.modules['agent_tools'] = agent_tools
 
 
 class TestResolvePosition(unittest.TestCase):
@@ -130,6 +137,54 @@ class TestFormatSize(unittest.TestCase):
 
     def test_megabytes(self):
         self.assertEqual(_format_size(2 * 1024 * 1024), '2.0MB')
+
+
+class TestGenerateVideoInvokeParams(unittest.TestCase):
+    """generate_video が image_processor へ送信する invoke_params のキー名検証 (Issue #41)"""
+
+    def test_invoke_params_use_camelcase_keys_for_image_processor(self):
+        """generate_video は image_processor が期待するキー名（image{n}X/Y/Width/Height, baseImage）で送信する"""
+        mock_lambda_client = MagicMock()
+        mock_lambda_client.invoke.return_value = {
+            'Payload': MagicMock(read=lambda: json.dumps({
+                'statusCode': 200,
+                'body': json.dumps({
+                    'url': 'https://example.com/v.mp4',
+                    'filename': 'v.mp4',
+                }),
+            }).encode())
+        }
+
+        with patch.dict(os.environ, {'IMAGE_PROCESSOR_FUNCTION': 'test-fn'}), \
+             patch('agent_tools.boto3') as mock_boto3:
+            mock_boto3.client.return_value = mock_lambda_client
+            generate_video(
+                duration=3,
+                video_format='MP4',
+                image1='test',
+                image1_position='100,200',
+                image1_size='400x300',
+                base_image='white',
+            )
+
+        # invoke の Payload から queryStringParameters を取り出す
+        kwargs = mock_lambda_client.invoke.call_args.kwargs
+        payload = json.loads(kwargs['Payload'])
+        params = payload['queryStringParameters']
+
+        # image_processor.parse_image_parameters が期待する camelCase キー
+        self.assertEqual(params.get('image1X'), '100')
+        self.assertEqual(params.get('image1Y'), '200')
+        self.assertEqual(params.get('image1Width'), '400')
+        self.assertEqual(params.get('image1Height'), '300')
+        self.assertEqual(params.get('baseImage'), 'white')
+
+        # 旧 snake_case キーは送信されない（受信側で無視されデフォルト値で上書きされる原因）
+        self.assertNotIn('image1_x', params)
+        self.assertNotIn('image1_y', params)
+        self.assertNotIn('image1_width', params)
+        self.assertNotIn('image1_height', params)
+        self.assertNotIn('base_image', params)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- `agent_tools.generate_video` が `image_processor` Lambda へ送信する `invoke_params` のキー名を、受信側 `parse_image_parameters` が期待する **camelCase に統一**
- Chat Agent から動画生成を行うとユーザー指定の位置/サイズ/ベース画像が無視されデフォルト値で生成されていた pre-existing bug を修正
- 静止画合成 (`compose_images`) は invoke_params 経路を使わないため影響なし

## 修正対象キー
| 旧 (snake_case) | 新 (camelCase) |
|---|---|
| `image{1,2,3}_x` | `image{1,2,3}X` |
| `image{1,2,3}_y` | `image{1,2,3}Y` |
| `image{1,2,3}_width` | `image{1,2,3}Width` |
| `image{1,2,3}_height` | `image{1,2,3}Height` |
| `base_image` | `baseImage` |

`generate_video` / `video_duration` / `video_format` / `format` / `baseOpacity` / `text*` は受信側もそのキー名を期待しており変更不要。

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `lambda/python/agent_tools.py` | `generate_video` の invoke_params キー名を camelCase に修正 |
| `test/lambda/test_agent_tools.py` | `TestGenerateVideoInvokeParams` クラス新設。boto3 をモックして Payload のキー検証 |

## Test plan
- [x] 新規ユニットテスト: `test_invoke_params_use_camelcase_keys_for_image_processor`
- [x] 全 207 件パス（206 → +1）
- [x] RED 確認: 修正前は `AssertionError: None != '100'`（キーが見つからない）
- [x] GREEN 確認: 修正後はパス
- [ ] CI（push 後自動）
- [ ] staging e2e + Chat Agent 経由の動画生成 動作確認（dev マージ後）

## 補足
テストインフラの副次的修正:
- `patch.dict('sys.modules', {'PIL': MagicMock()})` で agent_tools を import すると、with ブロック終了時に `sys.modules['agent_tools']` も削除されてしまい、後段の `mock.patch('agent_tools.X')` が解決できない問題に対処するため、明示的に再登録するロジックを追加。

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)