### PR TITLE
docs(spec,steering): 未記載情報の追記 (Phase 3, #50)

### DIFF
--- a/.kiro/specs/image-composition/requirements.md
+++ b/.kiro/specs/image-composition/requirements.md
@@ -284,10 +284,14 @@
 10. WHEN 動画生成時にテキストを指定する THEN テロップ付き合成画像がフレームに反映される
 11. WHEN フォント名を省略する THEN デフォルトの `NotoSansJP` が使用され、`NotoSansJP-Regular.ttf` がロードされる
 12. WHEN フォント名に `NotoSansJP` または `NotoSans` を指定する THEN 同一の `NotoSansJP-Regular.ttf` が使用される（エイリアス）
-13. WHEN フォント名に未登録のフォント名を指定する THEN デフォルトフォント（`NotoSansJP-Regular.ttf`）にフォールバックする
-14. WHEN フォント検索が失敗する THEN 検索パスは `lambda/python/fonts/` → `/opt/fonts`（Lambda Layer）の順で実行される
-15. WHEN すべての検索パスでフォントが見つからない THEN Pillow組み込みデフォルトフォント（`ImageFont.load_default`）にフォールバックし、警告ログを出力する
-16. WHEN TTFファイルのロードに失敗する（破損ファイル等）THEN Pillow組み込みデフォルトフォントにフォールバックし、警告ログを出力する
+13. WHEN フォント名に未登録の名前を指定する THEN **第1段フォールバック（ファイル名解決）** として `NotoSansJP-Regular.ttf` をTTFファイル名として採用する
+14. WHEN TTFファイルを検索する THEN 検索パスは `lambda/python/fonts/` → `/opt/fonts`（Lambda Layer）の順で実行される
+15. WHEN すべての検索パスでTTFファイルが見つからない THEN **第2段フォールバック（フォントオブジェクト）** として Pillow組み込みデフォルトフォント（`ImageFont.load_default`）が使用され、警告ログを出力する
+16. WHEN TTFファイルのロードに失敗する（破損ファイル等）THEN 同様に **第2段フォールバック** として Pillow組み込みデフォルトフォントが使用され、警告ログを出力する
+
+> フォントフォールバックの2段階構造:
+> - **第1段（19.13）**: 「未登録フォント名 → `NotoSansJP-Regular.ttf` というファイル名で検索を継続」。`text_renderer.py:_find_font_path` 内の `FONT_FILES.get(font_family, FONT_FILES['NotoSansJP'])` で実装
+> - **第2段（19.15, 19.16）**: 「TTFファイルそのものが利用できない → Pillow組み込みフォントオブジェクトに切り替え」。`text_renderer.py:load_font` の例外処理 + 検索失敗時パスで実装
 
 ## 技術的制約
 

--- a/.kiro/specs/image-composition/requirements.md
+++ b/.kiro/specs/image-composition/requirements.md
@@ -282,6 +282,12 @@
 8. WHEN テキストと画像を同時に指定する THEN 画像の上にテキストが重ねて描画される（Z-order: 画像→テキスト）
 9. WHEN テキストのみ（image1なし）を指定する THEN 透明背景上にテキストのみ描画される
 10. WHEN 動画生成時にテキストを指定する THEN テロップ付き合成画像がフレームに反映される
+11. WHEN フォント名を省略する THEN デフォルトの `NotoSansJP` が使用され、`NotoSansJP-Regular.ttf` がロードされる
+12. WHEN フォント名に `NotoSansJP` または `NotoSans` を指定する THEN 同一の `NotoSansJP-Regular.ttf` が使用される（エイリアス）
+13. WHEN フォント名に未登録のフォント名を指定する THEN デフォルトフォント（`NotoSansJP-Regular.ttf`）にフォールバックする
+14. WHEN フォント検索が失敗する THEN 検索パスは `lambda/python/fonts/` → `/opt/fonts`（Lambda Layer）の順で実行される
+15. WHEN すべての検索パスでフォントが見つからない THEN Pillow組み込みデフォルトフォント（`ImageFont.load_default`）にフォールバックし、警告ログを出力する
+16. WHEN TTFファイルのロードに失敗する（破損ファイル等）THEN Pillow組み込みデフォルトフォントにフォールバックし、警告ログを出力する
 
 ## 技術的制約
 

--- a/.kiro/specs/strands-agent/design.md
+++ b/.kiro/specs/strands-agent/design.md
@@ -267,6 +267,37 @@ class ChatHistoryManager:
 
 > 注: `timestamp`（SK）はミリ秒、`ttl` は秒。両者の単位が異なる点に注意。
 
+#### セッションIDのライフサイクル
+
+```
+[初回アクセス]                        [継続利用]                            [リセット/期限切れ]
+  ┌────────────────┐                   ┌────────────────┐                  ┌────────────────┐
+  │ Frontend       │                   │ Frontend       │                  │ Frontend       │
+  │ crypto.random  │                   │ localStorage   │                  │ 会話リセット    │
+  │ UUID() で生成  │ ──保存──▶         │ から読み出し   │ ──送信──▶        │ → 新UUID生成   │
+  └───────┬────────┘                   └───────┬────────┘                  └───────┬────────┘
+          │ POST /chat (sessionId)             │ POST /chat (sessionId)            │
+          ▼                                    ▼                                    ▼
+  ┌────────────────┐                   ┌────────────────┐                  ┌────────────────┐
+  │ Lambda         │                   │ Lambda         │                  │ Lambda         │
+  │ UUIDv4 検証    │                   │ Query history  │                  │ 履歴は別ID扱い │
+  │ → put_item     │                   │ → 履歴をAgent  │                  │ → 古いIDは     │
+  │   (1件目)      │                   │   コンテキスト │                  │   TTL=7日後に  │
+  │                │                   │   に投入       │                  │   自動削除     │
+  └────────────────┘                   └────────────────┘                  └────────────────┘
+```
+
+#### DynamoDBクエリパターン
+
+| 操作 | クエリ | 備考 |
+|------|-------|------|
+| 履歴取得 | `Query(KeyConditionExpression='sessionId = :sid', ScanIndexForward=True, ConsistentRead=True, Limit=N)` | 古い順（時系列）で取得。`ConsistentRead` で書き込み直後のレースを最小化 |
+| 履歴保存 | `PutItem(Item={sessionId, timestamp, role, content, ttl, ...})` | 同一timestampはミリ秒単位なので衝突は実質的に発生しない |
+| 履歴削除 | `Query` でセッション分のキーを取得 → `BatchWriter` で `DeleteItem`（ページネーション対応） | LastEvaluatedKey をループ処理 |
+| アクセス制御 | なし（API Gateway認証で制御） | DynamoDB自体にはセッション所有者の概念なし |
+
+> セキュリティ注意: セッションIDは非対称な認証情報ではない。第三者がIDを推測できれば履歴を閲覧可能。UUIDv4 のエントロピー（122ビット）が事実上の保護。
+
 ## 3. API設計
 
 ### 3.1 POST /chat - メッセージ送信

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -65,16 +65,26 @@ agent_handler.py
 
 ```
 image_processor.py
-   ├─ image_compositor.py     (create_composite_image, apply_base_opacity, parse_text_parameters)
+   ├─ image_compositor.py     (create_composite_image, parse_image_parameters, parse_text_parameters)
    │     └─ text_renderer.py  (render_text_overlay, load_font)
    ├─ image_fetcher.py        (fetch_images_parallel)
-   ├─ video_generator.py      (generate_video_from_image — ffmpeg呼び出し)
-   ├─ upload_manager.py       (create_presigned_url 等は別Lambda起動時のみ利用)
+   ├─ video_generator.py      (generate_video_from_image, get_video_mime_type, get_video_extension — ffmpeg呼び出し)
+   ├─ test_image_generator.py (generate_circle_image, generate_rectangle_image, generate_triangle_image)
    └─ error_handler.py        (ParameterError, ImageFetchError, ImageProcessingError)
 ```
 
 - `text_renderer` は `image_compositor` のみが利用する。直接 `image_processor` から呼ばない。
 - `error_handler` は全モジュールから利用される共通の例外定義。
+- `image_processor` は `upload_manager` を import しない。後者は独立した `UploadManagerFunction` Lambda として動作する（下記参照）。
+
+#### Upload Manager Lambda（upload_manager の起動経路）
+
+```
+upload_manager.py
+   └─ (外部のみ: boto3, PIL, botocore)
+```
+
+S3署名付きURL発行・アップロード済み画像一覧の独立Lambda。プロジェクト内の他Pythonモジュールには依存しない。Image Processor Lambda とは API Gateway 上で別パス（`/upload/*`）にマッピングされる。
 
 フォント:
 - `fonts/NotoSansJP-Regular.ttf` - 日本語フォント（テキストオーバーレイ用）

--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -46,6 +46,36 @@ image-processor-api/
 - `chat_history.py` - DynamoDB会話履歴管理
 - `requirements.txt` - Python依存関係
 
+### Lambda モジュール間の依存関係
+
+#### Chat Agent Lambda（agent_handler の起動経路）
+
+```
+agent_handler.py
+   ├─ agent_tools.py          (compose_images / generate_video / list_uploaded_images / delete_uploaded_image / get_help)
+   │     └─ agent_prompts.py  (resolve_position, resolve_size)
+   ├─ agent_prompts.py        (SYSTEM_PROMPT)
+   └─ chat_history.py         (ChatHistoryManager — DynamoDB)
+```
+
+- `agent_tools._last_media_result` はモジュールグローバル変数。`agent_handler.handle_chat` が呼び出し前にリセット → ツール実行後に取得（コンテキスト超過対策のための受け渡し）。
+- 循環依存はない。`agent_prompts` と `chat_history` は他モジュールに依存しない葉ノード。
+
+#### Image Processor Lambda（image_processor の起動経路）
+
+```
+image_processor.py
+   ├─ image_compositor.py     (create_composite_image, apply_base_opacity, parse_text_parameters)
+   │     └─ text_renderer.py  (render_text_overlay, load_font)
+   ├─ image_fetcher.py        (fetch_images_parallel)
+   ├─ video_generator.py      (generate_video_from_image — ffmpeg呼び出し)
+   ├─ upload_manager.py       (create_presigned_url 等は別Lambda起動時のみ利用)
+   └─ error_handler.py        (ParameterError, ImageFetchError, ImageProcessingError)
+```
+
+- `text_renderer` は `image_compositor` のみが利用する。直接 `image_processor` から呼ばない。
+- `error_handler` は全モジュールから利用される共通の例外定義。
+
 フォント:
 - `fonts/NotoSansJP-Regular.ttf` - 日本語フォント（テキストオーバーレイ用）
 

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -86,6 +86,66 @@ npm run test:selection       # 画像選択E2E
 npm run test:integration     # 統合E2E
 ```
 
+## テスト用環境変数
+
+テスト実行時にCloudFormation出力から取得して設定する。各環境（dev/staging/production）でスタック名サフィックスが異なる点に注意。
+
+| 環境変数 | 用途 | CDK出力キー | 備考 |
+|---------|------|----------|------|
+| `API_URL` | 画像合成APIエンドポイント。`/images/composite` を含む完全URL。Playwright設定では末尾を除去してbaseURLに使用 | `ApiUrl` (ImageProcessorApiStack) | 例: `.../prod/images/composite` |
+| `CHAT_API_URL` | Chat Agent APIのベースURL（末尾 `/chat` を含む）。`POST /chat`、`GET /chat/models`、`GET/DELETE /chat/history/{sessionId}` で使用 | `ChatApiUrl` (ImageProcessorApiStack) | 例: `.../prod/chat` |
+| `FRONTEND_URL` | フロントエンドURL（CloudFrontドメイン）。E2EテストのbaseURL | `FrontendUrl` (FrontendStack) | - |
+
+### CHAT_API_URL のフォールバック
+
+`test/e2e/chat-agent.api.spec.ts` は以下の順で URL を解決する:
+
+```typescript
+chatApiUrl: process.env.CHAT_API_URL
+         || process.env.API_URL?.replace(/\/images\/composite$/, '/chat')
+         || ''
+```
+
+`CHAT_API_URL` 未設定時は `API_URL` の末尾 `/images/composite` を `/chat` に置換して導出する。CI/手動テストでは明示的に指定するのが望ましい。
+
+### 取得方法（環境別）
+
+```bash
+# production
+export CHAT_API_URL=$(aws cloudformation describe-stacks --stack-name ImageProcessorApiStack \
+  --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" --output text)
+
+# staging / dev は -Staging / -Dev サフィックス
+export CHAT_API_URL=$(aws cloudformation describe-stacks --stack-name ImageProcessorApiStack-Dev \
+  --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" --output text)
+```
+
+## Chat Agent テストでのセッションID管理
+
+Chat AgentテストはDynamoDB会話履歴の影響を受けるため、セッションIDの扱いに注意が必要。
+
+### セッションID生成パターン
+
+| パターン | 用途 | 実装例 |
+|---------|------|-------|
+| テストスイートごとに固定UUID | フロー全体で会話履歴を共有・累積したい場合（E2E安定化） | `test.beforeAll` で `randomUUID()` を生成し describe 全体で共有 |
+| テストごとに新規UUID | 履歴の影響を受けたくない独立テスト | 各 `test()` 内で `randomUUID()` を呼ぶ |
+| エラーケース用 | バリデーションテスト等 | data に直接 `randomUUID()` を渡す |
+
+### 履歴クリーンアップ
+
+会話履歴を蓄積しないため、テスト終了時に `DELETE /chat/history/{sessionId}` で削除する:
+
+```typescript
+test.afterAll(async ({ request }) => {
+  await request.delete(`${TEST_CONFIG.chatApiUrl}/history/${sessionId}`).catch(() => {})
+})
+```
+
+### DynamoDB ConsistentRead
+
+Chat履歴の取得は `ConsistentRead=True` で実行されるが、書き込み直後（数十ms以内）の取得は競合することがある。`POST /chat` 直後に `GET /chat/history` するテストでは小さな待機を入れるかリトライを実装する。
+
 ## テストの書き方
 
 ### ユニットテスト構造


### PR DESCRIPTION
## 概要

Issue #47 Phase 3 として、実装には存在するがどのドキュメントにも記載されていなかった重要情報を追記。

親Issue: #47
対応Issue: #50

## 完了タスク

| # | 対象ファイル | 追記内容 | 参照実装 |
|---|-----------|---------|---------|
| 3-1 | `steering/structure.md` | Chat Agent / Image Processor Lambda のモジュール間依存関係を図示。`_last_media_result` グローバル変数による値受け渡しも明記 | agent_handler.py:125-126,365 / image_processor.py |
| 3-2 | `steering/testing.md` | 「テスト用環境変数」表（API_URL / CHAT_API_URL / FRONTEND_URL）+ CHAT_API_URL フォールバック解決順 + 「Chat Agent テストでのセッションID管理」セクション（生成パターン3種・履歴クリーンアップ・ConsistentRead注意） | chat-agent.api.spec.ts:35 |
| 3-3 | `specs/image-composition/requirements.md` | Req 19 に AC 19.11〜19.16 を追加（フォント検索パス順序・NotoSansJP/NotoSans エイリアス・各種フォールバック挙動） | text_renderer.py:15-48 |
| 3-4 | `specs/strands-agent/design.md` | セッションIDのライフサイクル図 + DynamoDBクエリパターン表 + セキュリティ注意（UUIDv4のエントロピーが事実上の保護） | chat_history.py:80-128 |

## 完了基準

- [x] ドキュメントを読むだけで、セッション管理・フォント選択・モジュール依存の実装方針が把握できる
- [x] Phase 1 で追記したセッションID命名規則・TTL管理仕様と統合的に読める

## 検証で実装と一致を確認した項目

- text_renderer.py の `FONT_SEARCH_PATHS = [lambda/python/fonts, /opt/fonts]` ↔ Req 19.14
- text_renderer.py の `FONT_FILES = {NotoSansJP, NotoSans}` （同一TTF） ↔ Req 19.12
- text_renderer.py の `_find_font_path` 未登録時 NotoSansJP fallback ↔ Req 19.13
- text_renderer.py の `load_font` Pillow `load_default` fallback ↔ Req 19.15, 19.16
- agent_handler.py:125-126, 365 の import 構造 ↔ structure.md 依存関係図
- chat-agent.api.spec.ts:35 の `CHAT_API_URL || API_URL.replace(/\/images\/composite$/, '/chat')` ↔ testing.md フォールバック
- chat_history.py:80-128 の `ConsistentRead=True`, `ScanIndexForward=True`, `BatchWriter`, ページネーション ↔ design.md DynamoDBクエリパターン

## 差分統計

```
.kiro/specs/image-composition/requirements.md |  6 +++
.kiro/specs/strands-agent/design.md           | 31 ++++++++++++++
.kiro/steering/structure.md                   | 30 ++++++++++++++
.kiro/steering/testing.md                     | 60 +++++++++++++++++++++++++++
4 files changed, 127 insertions(+)
```

## テスト

- [x] ドキュメント追記のみ（コード変更なし）
- [x] CDK・実装ファイル未変更