### PR TITLE
refactor(api,agent): baseOpacityクランプロジック統合 (#39)

### DIFF
--- a/lambda/python/agent_tools.py
+++ b/lambda/python/agent_tools.py
@@ -204,11 +204,10 @@ def compose_images(
                 'padding': pad,
             }
 
-    # 合成実行
-    opacity = max(0, min(100, base_opacity))
+    # 合成実行（クランプは apply_base_opacity 側に集約 - Issue #39）
     composite = create_composite_image(base_img, img1, img2, img3, params,
                                        text_params=text_params if text_params else None,
-                                       base_opacity=opacity)
+                                       base_opacity=base_opacity)
 
     # S3に保存してCloudFront URLを生成
     from datetime import datetime
@@ -389,7 +388,8 @@ def generate_video(
         'image1Width': str(sz1[0]),
         'image1Height': str(sz1[1]),
         'baseImage': base_image,
-        'baseOpacity': str(max(0, min(100, base_opacity))),
+        # クランプは image_processor 経由で apply_base_opacity 側に集約 (Issue #39)
+        'baseOpacity': str(base_opacity),
         'format': 'png',
         'generate_video': 'true',
         'video_duration': str(duration),

--- a/lambda/python/image_compositor.py
+++ b/lambda/python/image_compositor.py
@@ -171,11 +171,14 @@ def apply_base_opacity(base_img: Image.Image, opacity: int) -> Image.Image:
 
     Args:
         base_img: ベース画像（RGBAモード）
-        opacity: 透明度（0=完全透明、100=不透明）
+        opacity: 透明度（0=完全透明、100=不透明、範囲外は内部で0-100にクランプ）
 
     Returns:
         Image.Image: opacity適用後のベース画像
     """
+    # 範囲外の値を0-100にクランプ（呼び出し側でクランプ不要）
+    opacity = max(0, min(100, opacity))
+
     if opacity >= 100:
         return base_img
     if opacity <= 0:

--- a/lambda/python/image_processor.py
+++ b/lambda/python/image_processor.py
@@ -454,7 +454,7 @@ def handler(event, context):
             base_opacity_param = int(query_params.get('baseOpacity', '100'))
         except (ValueError, TypeError):
             base_opacity_param = 100  # 非数値はデフォルトにフォールバック (Issue #37)
-        base_opacity_param = max(0, min(100, base_opacity_param))  # 0-100にクランプ
+        # クランプは apply_base_opacity 側に集約 (Issue #39)
         format_param = query_params.get('format', 'png')
 
         # 動画生成パラメータ


### PR DESCRIPTION
## 概要

Closes #39

`max(0, min(100, x))` の baseOpacity クランプロジックが3箇所に重複していたため、`apply_base_opacity()` 内部に集約してDRY化。

## 変更内容

| ファイル | 変更 |
|---|---|
| `lambda/python/image_compositor.py` | `apply_base_opacity()` 内部でクランプを実施。docstring更新 |
| `lambda/python/image_processor.py` | handler 内の重複クランプを削除 |
| `lambda/python/agent_tools.py` | `compose_images` / `generate_video` の重複クランプを削除 |

## 設計方針

issue #39 の選択肢A（apply_base_opacity 自体にクランプを内包）を採用。テスト名 `test_opacity_clamp_over_100` の意図とも一致。

## 受入基準

- [x] クランプは1箇所のみで実施
- [x] 既存ユニットテスト全パス（208/208 OK）
- [x] >100 / <0 の値でも従来同様の挙動

## テスト結果

\`\`\`
PYTHONPATH=lambda/python python3 -m unittest discover -s test/lambda
Ran 208 tests in 12.281s
OK (skipped=1)
\`\`\`

## 関連

PR #21 レビューフォローアップ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)