### PR TITLE
test(agent,api): baseOpacityのテストカバレッジ補完 (#40)

### DIFF
--- a/test/lambda/test_agent_tools.py
+++ b/test/lambda/test_agent_tools.py
@@ -21,7 +21,7 @@ from agent_prompts import resolve_position, resolve_size, POSITION_MAP, DEFAULT_
 # PILがない環境でもテスト可能にする
 with patch.dict('sys.modules', {'PIL': MagicMock(), 'PIL.Image': MagicMock()}):
     import agent_tools
-    from agent_tools import get_help, _format_size, generate_video
+    from agent_tools import get_help, _format_size, generate_video, compose_images
 
 # patch.dict はブロック終了時に sys.modules を復元してしまい、import した
 # agent_tools が消えるため、後段の mock.patch('agent_tools.X') が解決できない。
@@ -185,6 +185,41 @@ class TestGenerateVideoInvokeParams(unittest.TestCase):
         self.assertNotIn('image1_width', params)
         self.assertNotIn('image1_height', params)
         self.assertNotIn('base_image', params)
+
+
+class TestComposeImagesBaseOpacity(unittest.TestCase):
+    """compose_images が base_opacity を create_composite_image に透過するテスト (Issue #40)"""
+
+    def test_compose_images_passes_base_opacity_through(self):
+        """compose_images の base_opacity 引数が create_composite_image(base_opacity=...) まで透過する"""
+        # compose_images 内部でインライン import されるため image_fetcher / image_compositor に patch する
+        import image_fetcher
+        import image_compositor
+
+        mock_image = MagicMock()
+        mock_image.size = (2000, 1000)
+
+        composite_mock = MagicMock()
+        composite_mock.save = MagicMock()
+
+        with patch.object(image_fetcher, 'fetch_image', return_value=mock_image), \
+             patch.object(image_compositor, 'create_composite_image', return_value=composite_mock) as mock_create_composite, \
+             patch('agent_tools._get_s3_client') as mock_s3_factory, \
+             patch.dict(os.environ, {'S3_RESOURCES_BUCKET': 'test-bucket', 'CLOUDFRONT_DOMAIN': 'cdn.test'}):
+            mock_s3_factory.return_value = MagicMock()
+
+            compose_images(
+                image1='test',
+                image1_position='中央',
+                image1_size='400x400',
+                base_image='white',
+                base_opacity=42,
+            )
+
+            # create_composite_image が base_opacity=42 を受け取って呼ばれていること
+            self.assertTrue(mock_create_composite.called)
+            _, kwargs = mock_create_composite.call_args
+            self.assertEqual(kwargs.get('base_opacity'), 42)
 
 
 if __name__ == '__main__':

--- a/test/lambda/test_image_compositor_test.py
+++ b/test/lambda/test_image_compositor_test.py
@@ -521,23 +521,26 @@ class TestBaseOpacity(unittest.TestCase):
         self.assertEqual(result.getpixel((50, 50)), (0, 0, 0, 0))
 
     def test_opacity_50_half_transparent(self):
-        """opacity=50でアルファが約半分になる"""
+        """opacity=50で複数座標(角・中央)のRGB保持・alpha変化を検証する"""
         base = Image.new('RGBA', (100, 100), (255, 0, 0, 255))
         result = apply_base_opacity(base, 50)
-        pixel = result.getpixel((50, 50))
-        self.assertEqual(pixel[0], 255)  # R保持
-        self.assertEqual(pixel[1], 0)    # G保持
-        self.assertEqual(pixel[2], 0)    # B保持
-        self.assertAlmostEqual(pixel[3], 127, delta=2)  # alpha ≈ 127
+        # 4隅と中央の5座標で検証
+        for x, y in [(0, 0), (99, 0), (0, 99), (99, 99), (50, 50)]:
+            pixel = result.getpixel((x, y))
+            self.assertEqual(pixel[0], 255, f"R保持 at ({x},{y})")
+            self.assertEqual(pixel[1], 0, f"G保持 at ({x},{y})")
+            self.assertEqual(pixel[2], 0, f"B保持 at ({x},{y})")
+            self.assertAlmostEqual(pixel[3], 127, delta=2,
+                                   msg=f"alpha ≈ 127 at ({x},{y})")
 
-    def test_opacity_clamp_over_100(self):
-        """100超の値でも画像が返される（create_composite_imageがクランプ）"""
+    def test_opacity_at_or_above_100_returns_unchanged(self):
+        """opacity>=100は早期リターンしてベース画像をそのまま返す（apply_base_opacity内のクランプ経路）"""
         base = Image.new('RGBA', (100, 100), (255, 255, 255, 255))
         result = apply_base_opacity(base, 150)
         self.assertEqual(result.getpixel((50, 50)), (255, 255, 255, 255))
 
-    def test_opacity_clamp_negative(self):
-        """負の値で完全透明になる"""
+    def test_opacity_at_or_below_0_returns_fully_transparent(self):
+        """opacity<=0は早期リターンして完全透明画像を返す（apply_base_opacity内のクランプ経路）"""
         base = Image.new('RGBA', (100, 100), (255, 255, 255, 255))
         result = apply_base_opacity(base, -10)
         self.assertEqual(result.getpixel((50, 50)), (0, 0, 0, 0))

--- a/test/lambda/test_image_processor.py
+++ b/test/lambda/test_image_processor.py
@@ -2,6 +2,7 @@ import sys
 import os
 import unittest
 import json
+import base64
 from unittest.mock import patch, MagicMock
 from io import BytesIO
 from PIL import Image
@@ -152,6 +153,45 @@ class TestImageProcessor(unittest.TestCase):
         # create_composite_image が base_opacity=100（デフォルト）で呼ばれていること
         _, kwargs = mock_create_composite.call_args
         self.assertEqual(kwargs.get('base_opacity'), 100)
+
+    @patch('image_processor.fetch_images_parallel')
+    def test_handler_base_opacity_query_to_png_alpha(self, mock_fetch_parallel):
+        """baseOpacityクエリ→出力PNGのalpha値まで反映される統合テスト (Issue #40)"""
+        # ベース画像と前景画像を実体で用意（モック合成しない）
+        base_image = Image.new('RGBA', (2000, 1000), (255, 255, 255, 255))
+        fg_image = Image.new('RGBA', (50, 50), (255, 0, 0, 255))
+        mock_fetch_parallel.return_value = {
+            'base': base_image,
+            'image1': fg_image,
+        }
+
+        event = {
+            'queryStringParameters': {
+                'baseImage': 'test',
+                'image1': 'test',
+                'image1X': '1500',
+                'image1Y': '900',
+                'image1Width': '50',
+                'image1Height': '50',
+                'baseOpacity': '50',
+                'format': 'png',
+            }
+        }
+
+        result = image_processor.handler(event, {})
+        self.assertEqual(result['statusCode'], 200)
+
+        # 出力PNGをデコードしてアルファ値を検証
+        png_bytes = base64.b64decode(result['body'])
+        out_image = Image.open(BytesIO(png_bytes)).convert('RGBA')
+
+        # 前景画像が配置されていない領域（左上付近）はベースのみ。
+        # baseOpacity=50 → alpha ≈ 127 (255 * 0.5)
+        bg_pixel = out_image.getpixel((10, 10))
+        self.assertEqual(bg_pixel[0], 255)  # R保持
+        self.assertEqual(bg_pixel[1], 255)  # G保持
+        self.assertEqual(bg_pixel[2], 255)  # B保持
+        self.assertAlmostEqual(bg_pixel[3], 127, delta=2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 概要

Closes #40

PR #21 で追加された baseOpacity 機能のテスト抜けを補完。

## 追加・改名内容

### 新規テスト3件

| ファイル | テスト | 内容 |
|---|---|---|
| `test/lambda/test_agent_tools.py` | `test_compose_images_passes_base_opacity_through` | `compose_images` の `base_opacity` 引数が `create_composite_image(base_opacity=...)` まで透過することをモックで検証 |
| `test/lambda/test_image_processor.py` | `test_handler_base_opacity_query_to_png_alpha` | `baseOpacity` クエリ → 出力 PNG の alpha 値まで反映される統合テスト |
| `test/lambda/test_image_compositor_test.py` | `test_opacity_50_half_transparent`（拡張） | 4隅+中央の5座標で RGB 保持と alpha ≈ 127 を網羅的に検証 |

### テスト名改名2件

意図を明確にするため、apply_base_opacity 内のクランプ経路ではなく早期リターン経路を見ていることを名前で示す。

- `test_opacity_clamp_over_100` → `test_opacity_at_or_above_100_returns_unchanged`
- `test_opacity_clamp_negative` → `test_opacity_at_or_below_0_returns_fully_transparent`

## 受入基準

- [x] 新規テスト最低3件（Agent経路1, 統合1, 網羅性1）
- [x] テスト名2件改名
- [x] 全テストパス（210/210 OK）

## テスト結果

\`\`\`
PYTHONPATH=lambda/python python3 -m unittest discover -s test/lambda
Ran 210 tests in 17.715s
OK (skipped=1)
\`\`\`

## 関連

PR #21 レビューフォローアップ。#39 とは独立してマージ可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)