### PR TITLE
chore(amazonq): エージェント設定を新スキーマに移行

### DIFF
--- a/.amazonq/agents/default.json
+++ b/.amazonq/agents/default.json
@@ -1,6 +1,5 @@
 {
-  "name": "default-agent",
-  "version": "1.0.0",
+  "name": "q_ide_default",
   "description": "Default agent configuration",
   "mcpServers": {
     "awslabs.aws-documentation-mcp-server": {
@@ -90,11 +89,16 @@
       ]
     }
   },
-  "includedFiles": [
-    "AmazonQ.md",
-    "README.md",
-    ".amazonq/rules/**/*.md"
+  "resources": [
+    "file://AmazonQ.md",
+    "file://README.md",
+    "file://.amazonq/rules/**/*.md"
   ],
-  "resources": [],
-  "promptHooks": []
+  "prompt": "",
+  "toolAliases": {},
+  "hooks": {
+    "agentSpawn": [],
+    "userPromptSubmit": []
+  },
+  "useLegacyMcpJson": true
 }


### PR DESCRIPTION
## 概要

Amazon Q CLI の最新版がエージェント設定スキーマを `q_ide_default` 形式へ移行したため、`.amazonq/agents/default.json` を新フォーマットに更新する。

issue #58 (composite-default.json spec) の作業中に worktree 内で Amazon Q が自動更新したスキーマ移行分を、独立した PR として切り出した。

## 変更内容

- `.amazonq/agents/default.json`:
  - `name`: `default-agent` → `q_ide_default`
  - `version` フィールド削除（スキーマ自体で管理されるようになった）
  - `includedFiles` → `resources`（`file://` URI 形式）
  - `promptHooks` → `hooks` (agentSpawn / userPromptSubmit に細分化)
  - `prompt`, `toolAliases`, `useLegacyMcpJson` フィールドを追加

## テスト

- [x] ユニットテストが通過 → 該当なし（設定ファイルのみ）
- [x] APIテストが通過 → 該当なし
- [x] E2Eテストが通過 → 該当なし
- [x] Chat Agent APIテストが通過 → 該当なし
- [x] 手動テスト完了 → Amazon Q CLI が正常に起動することを確認（運用上は本プロジェクトで利用者なし）

## ドキュメント更新確認

- [x] **上記いずれにも該当しない** — `.amazonq/` 配下のローカル開発ツール設定のみ。実装やAPIに影響なし

## 関連Issue

なし（Amazon Q CLI のスキーマ追従）