### PR TITLE
docs(specs): タスク 21.11 (e2e) を完了に更新

### DIFF
--- a/.kiro/specs/image-composition/tasks.md
+++ b/.kiro/specs/image-composition/tasks.md
@@ -528,7 +528,7 @@
   - フロント `compositeDefaults` ストアの fetch 失敗時フォールバック
   - _要件: 21.3〜21.5, 21.11_
 
-- [ ] 21.11 e2e/統合テスト
+- [x] 21.11 e2e/統合テスト
   - 既存30件の e2e テストを実行し、期待値画像の再生成が必要か確認
   - 必要なら `scripts/regenerate-expected-images.py` を実行して期待値更新
   - 破壊的変更（baseImage 黒、video_format MP4、image1/2/3 のデフォルト座標変更）に該当するテストの期待値を更新


### PR DESCRIPTION
## 概要

PR #63 (Issue #58 実装) マージ後に CI/CD パイプラインで e2e テストが通過したため、`tasks.md` のサブタスク 21.11 を `[ ]` → `[x]` に更新する。

これで Issue #58 のサブタスク **21.1〜21.13 すべてが完了** となる。

## 変更内容

- `.kiro/specs/image-composition/tasks.md`: 21.11 を `[x]` に更新

## テスト

- [x] ユニットテストが通過 → 該当なし（ドキュメント更新のみ）
- [x] APIテストが通過 → 該当なし
- [x] E2Eテストが通過 → 該当なし
- [x] 手動テスト完了 → 該当なし

## ドキュメント更新確認

- [x] **`tasks.md` のチェックボックス**を `[x]` に更新した（仕様駆動開発ルール3）
- [x] **上記いずれにも該当しない** — タスク進捗反映のみ

## 関連

- Issue #58（実装）
- PR #63（実装、マージ済み）