### PR TITLE
chore(test): playwright.config.ts の baseURL 環境変数化と .ts-only 制限 (#68)

### DIFF
--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -7,6 +7,8 @@ import path from 'path';
  */
 export default defineConfig({
   testDir: './e2e',
+  // .spec.ts のみを test として認識（コンパイル artifact .spec.js / .spec.d.ts を除外）
+  testMatch: /\.spec\.ts$/,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -66,7 +68,7 @@ export default defineConfig({
       name: 'frontend-tests',
       testMatch: /.*frontend\.spec\.ts/,
       use: {
-        baseURL: 'http://localhost:5173',
+        baseURL: process.env.FRONTEND_URL || 'http://localhost:3000',
       },
     },
     {
@@ -74,7 +76,7 @@ export default defineConfig({
       testMatch: /frontend-api\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: process.env.FRONTEND_URL || 'http://localhost:5173',
+        baseURL: process.env.FRONTEND_URL || 'http://localhost:3000',
       },
     },
     {
@@ -82,7 +84,7 @@ export default defineConfig({
       testMatch: /upload-functionality\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: process.env.FRONTEND_URL || 'http://localhost:5173',
+        baseURL: process.env.FRONTEND_URL || 'http://localhost:3000',
       },
     },
     {
@@ -90,7 +92,7 @@ export default defineConfig({
       testMatch: /image-selection\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: process.env.FRONTEND_URL || 'http://localhost:5173',
+        baseURL: process.env.FRONTEND_URL || 'http://localhost:3000',
       },
     },
     {
@@ -98,7 +100,7 @@ export default defineConfig({
       testMatch: /integration-workflow\.spec\.ts/,
       use: {
         ...devices['Desktop Chrome'],
-        baseURL: process.env.FRONTEND_URL || 'http://localhost:5173',
+        baseURL: process.env.FRONTEND_URL || 'http://localhost:3000',
       },
     },
     {


### PR DESCRIPTION
## 概要

PR #67 でテストファイル側の URL を環境変数化したが、`test/playwright.config.ts` の `frontend-tests` プロジェクトには `baseURL: 'http://localhost:5173'` が固定で残っていた。これを環境変数化し、合わせてコンパイル artifact (`*.spec.js` / `*.spec.d.ts`) を Playwright が拾わないよう `testMatch` を `/\.spec\.ts$/` に明示限定する。

Closes #68

## 変更内容

- `frontend-tests` の `baseURL` を `process.env.FRONTEND_URL || 'http://localhost:3000'` に変更（issue 指示）
- `api-demo-tests` / `upload-tests` / `selection-tests` / `integration-tests` の default を `5173` → `3000` に統一（Vite dev server は `frontend/vite.config.js` で port 3000 設定のため、5173 default は実態と乖離していた）
- `defineConfig` トップレベルに `testMatch: /\.spec\.ts$/` を追加し、`.spec.js` / `.spec.d.ts` を一切検出しないよう制約
- `chat-agent-tests` は意図的に staging/CloudFront URL がデフォルトのため変更対象外

## テスト

- [x] ユニットテストが通過（変更範囲外、影響なし）
- [x] `npx playwright test --list` で **433 tests / 16 files** を確認（変更前と同数）
- [x] ダミー `__should-be-ignored.spec.js` / `__should-be-ignored.spec.d.ts` を作成しても検出されないことを確認

## ドキュメント更新確認

- [x] 上記いずれにも該当しない（テスト設定のみの変更）

## 関連

- PR #67（frontend.spec.ts の URL 環境変数化、本 PR の前段）
- Closes #68