### PR TITLE
docs(steering): Lambda コールドスタート計測手順を workflow.md に追加 (#71)

### DIFF
--- a/.kiro/steering/workflow.md
+++ b/.kiro/steering/workflow.md
@@ -237,6 +237,28 @@ ENVIRONMENT=<env> ./scripts/deploy.sh
 - ユーザーフィードバック
 - 技術的負債
 
+### Lambda コールドスタート計測（パフォーマンス調査）
+
+新しい依存（フォント・大きなライブラリ等）を Lambda に同梱する際は、**コールドスタートへの影響**を CloudWatch Insights で計測する。
+
+```bash
+# Lambda 関数名を取得（例: production の ImageProcessor）
+FUNC_NAME=$(aws cloudformation list-stack-resources --stack-name ImageProcessorApiStack \
+  --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function' && contains(LogicalResourceId, 'ImageProcessor')].PhysicalResourceId" \
+  --output text)
+
+# 直近 1 時間の Init Duration / Duration を集計
+aws logs start-query \
+  --log-group-name "/aws/lambda/${FUNC_NAME}" \
+  --start-time $(($(date +%s) - 3600)) \
+  --end-time $(date +%s) \
+  --query-string 'fields @timestamp, @initDuration, @duration | filter @type = "REPORT" | stats avg(@initDuration), max(@initDuration), avg(@duration), count() by bin(5m)'
+```
+
+- `@initDuration` が記録されるのはコールドスタートのみ（ウォーム時は欠損）
+- 機能 ON/OFF による比較は、リクエストパラメータでフィルタした 2 クエリを並べて差分を見る
+- 影響が **>500ms 増加** なら最適化検討（Lambda Layer 化、サブセット化、provisioned concurrency 等）
+
 ### インシデント対応
 1. 検出: CloudWatchアラーム
 2. 評価: ログとメトリクスを確認


### PR DESCRIPTION
## 概要

Issue #71 の調査結果と再利用可能な計測手順を steering に集約。NotoSansJP フォント (v3.2.0 導入、9.6MB) のコールドスタート影響をコード解析で確認し、**最適化実装は不要**と判断。今後同様の調査が必要になった際の手順を `workflow.md` に追加した。

Refs #71（最適化実装は不要のため、issue は調査結果コメント後に close 予定）

## コード解析の結論

### text_renderer は完全に遅延ロード済み

| 場所 | import 形態 | 影響 |
|------|------------|------|
| `image_compositor.py:327` | 関数内 `from text_renderer import render_text_overlay` | **lazy** |
| `image_processor.py:516` | 関数内 `from text_renderer import _parse_color` | **lazy** |
| `text_renderer.py` トップレベル | `from PIL import Image, ImageDraw, ImageFont` | クラス参照のみ・I/O なし |

**Init Duration への影響**: なし（text_renderer モジュール自体が `text_params` 使用時のみロードされる）

### フォントファイルの読み込みも遅延

`load_font()` 内で `ImageFont.truetype(font_path, size)` が呼ばれた時点で初めて 9.6MB の TTF が読まれる。`text_params` 不使用リクエストでは一切発生しない。最初のテキストリクエストで一度読み、以降は warm な実行コンテキスト内でキャッシュされる。

### パッケージサイズ

9.6MB 加算のみ（Lambda コードダウンロード時間に微小に影響）。機能未使用時の性能影響は無視できるレベル。

## 変更内容

`.kiro/steering/workflow.md` の「監視ワークフロー」節に「**Lambda コールドスタート計測（パフォーマンス調査）**」サブセクションを追加。

- CloudWatch Insights クエリ（`@initDuration` を 5 分ビンで集計）
- Lambda 関数名の動的取得方法（CFN list-stack-resources）
- 機能 ON/OFF 比較の進め方
- 最適化判断基準（>500ms 増加なら Lambda Layer / サブセット化 / provisioned concurrency 検討）

## テスト

- [x] 既存テストへの影響なし（ドキュメント追加のみ）
- [x] 解析結果はコードリーディング済み: image_processor.py:516 / image_compositor.py:327 / text_renderer.py 全体

## ドキュメント更新確認

- [x] 上記いずれにも該当しない（steering 拡充のみ。仕様変更なし、API 変更なし、依存追加なし）

## 関連

- PR #62（v3.2.0、フォントバンドル導入元）
- Refs #71

## 注

PR #74（#70 対応）と同じ `workflow.md` を編集していますが、編集セクションが異なるため衝突なし想定。先にどちらが merge されても、後の PR は clean に rebase 可能。