### PR TITLE
docs(steering,history): history.md の役割を conventions.md に明文化 (#72)

### DIFF
--- a/.kiro/steering/conventions.md
+++ b/.kiro/steering/conventions.md
@@ -366,3 +366,44 @@ export const MAX_IMAGE_SIZE = 5 * 1024 * 1024
 export const DEFAULT_TIMEOUT = 30000
 export const API_BASE_URL = import.meta.env.VITE_API_URL
 ```
+
+## ドキュメント規約
+
+### history.md の役割
+
+`history.md`（リポジトリルート）は、プロジェクトの **経緯（why／context）** を残すドキュメント。実装の「結果（what）」は git log から復元できるが、「なぜそう判断したか」「どんな背景・代替案・トレードオフがあったか」は commit message では十分記録できない。`history.md` はその欠落を補うために維持する。
+
+#### 役割の書き分け
+
+| ドキュメント | 主な内容 | 粒度 |
+|-------------|---------|------|
+| `git log` / commit message | 結果（what） | コミット単位 |
+| GitHub Releases | リリースノート（GH UI から作成） | リリース単位 |
+| `history.md` | **経緯（why）** | 大きな機能・設計判断単位 |
+
+> `CHANGELOG.md` は採用しない。リリースノートは GitHub Releases、経緯は `history.md` で役割分担する。
+
+#### 更新タイミング
+
+- 新機能の追加・大きな設計変更・後方互換性に関わる判断を行ったとき
+- 単純なバグ修正や微小なリファクタには不要（commit message で十分）
+- **リリース粒度ではなく判断粒度**で書く
+
+#### 書き方
+
+```markdown
+## YYYY-MM-DD: <変更タイトル> (Issue #N)
+
+### <サブセクション>
+- **<コンポーネント名>**: <変更内容と why>
+- **<決定事項>**: <選択した案／代替案を退けた理由>
+
+### テスト
+- <テスト追加内容>
+```
+
+#### 留意点
+
+- リリースノート形式（Keep a Changelog 等）に寄せない
+- 既存履歴は追記方式で更新（過去エントリの大幅な書き換えは避ける）
+- `history.md` で十分な内容を steering / specs に二重化しない（Single Source of Truth）

--- a/history.md
+++ b/history.md
@@ -1,5 +1,9 @@
 # 画像合成REST API 開発履歴
 
+> **このファイルの役割**: 大きな機能追加・設計変更の **経緯（why／context）** を残すドキュメント。
+> git log（結果＝what）と GitHub Releases（リリースノート）の補完。
+> 詳しい役割・書き分け・更新タイミングは [.kiro/steering/conventions.md](.kiro/steering/conventions.md) の「ドキュメント規約 / history.md の役割」セクションを参照。
+
 ## 2026-04-01: ベース画像の透明度（opacity）パラメータ追加 (Issue #7)
 
 ### ベース画像透明度


### PR DESCRIPTION
## 概要

Issue #72 の方針決定: **C 案（現状維持 + 役割明文化）** を採用。

`history.md` は Amazon Q 由来の慣習（PR #64 で関連ファイル削除済み）として導入されたが、以下の理由で継続維持する:

- git log は「結果（what）」のみで、設計判断・代替案・トレードオフ等の経緯（why／context）は commit message に十分残せない
- CHANGELOG（リリース単位の機能列挙）でも、GitHub Releases（リリースノート）でもない、独自の役割がある
- 既に蓄積された経緯ログ（v2.6.0 の動画生成、Issue #13 のテキストオーバーレイ等）を捨てたくない

役割を明文化することで、「なぜこのファイルが存在するか」「何を書くべきか」を新規読者・AI エージェントが理解できる状態にする。

Closes #72

## 変更内容

### `.kiro/steering/conventions.md`

末尾に「**ドキュメント規約 / history.md の役割**」セクションを追加。

- 役割の書き分けマトリクス（git log / GitHub Releases / history.md の各粒度・内容）
- CHANGELOG.md は採用しない方針を明記
- 更新タイミング（大きな機能追加・設計変更・後方互換性判断時 / 判断粒度）
- 書き方テンプレート（`YYYY-MM-DD: <タイトル> (Issue #N)` 形式）
- 留意点（リリースノート形式に寄せない / 追記方式 / Single Source of Truth）

### `history.md`

冒頭に役割を示すブロッククオートと `conventions.md` への参照を追加。新規読者・AI エージェントが一目で目的を理解できるようにした。

## テスト

- [x] 既存テストへの影響なし（ドキュメントのみの変更）
- [x] `history.md` 内容自体は変更なし（追記のみ）

## ドキュメント更新確認

- [x] 上記いずれにも該当しない（ドキュメント規約の追加のみ）

## 関連

- PR #64（Amazon Q 関連ファイル削除、本 issue の動機）
- PR #62（v3.2.0 release、history.md 取り扱いに関する議論の発端）
- Closes #72