### PR TITLE
test(e2e): サムネイル生成待機を5s→15sに延長 (#82)

### DIFF
--- a/test/e2e/upload-comprehensive.api.spec.ts
+++ b/test/e2e/upload-comprehensive.api.spec.ts
@@ -86,7 +86,10 @@ test.describe('S3アップロード機能包括テスト', () => {
     expect(uploadResponse.status()).toBe(200);
 
     // S3トリガー → Lambda によるサムネイル生成を待機
-    await new Promise(resolve => setTimeout(resolve, 5000));
+    // 15s に拡張: production で稀にフォールバック URL（元画像）が返り content-type
+    // 不一致になる事象（issue #82）の暫定対応。Lambda コールドスタート + S3 整合性
+    // ウィンドウを吸収。根本対応（polling 化）は同 issue で別途検討。
+    await new Promise(resolve => setTimeout(resolve, 15000));
 
     // アップロードした画像をキーで特定してサムネイルを確認
     const listResponse = await request.get(`${UPLOAD_API_URL}/images`);


### PR DESCRIPTION
## 概要

production の post-deploy E2E で稀に発生する **サムネイル生成確認テストの flaky 失敗（content-type が `image/jpeg` で返る）** に対する暫定対応。アップロード後の待機時間を 5s → 15s に延長し、Lambda コールドスタート + S3 整合性ウィンドウを吸収する。

## 変更内容

- `test/e2e/upload-comprehensive.api.spec.ts` の「サムネイル生成確認」テストの待機を `5000ms` → `15000ms` に延長
- 経緯コメントを `setTimeout` 直前に追記（issue #82 への参照含む）

## テスト

- [x] ユニットテストが通過（型チェック `npx tsc --noEmit` のみ実施。本変更はテスト待機時間の調整であり実行系の単体テストは影響なし）
- [x] APIテストが通過（`npm run test:api`） — dev マージ後 staging post-deploy E2E で **108 件 pass**（[run 25646528346](https://github.com/ikeom-je/image-composite-agent/actions/runs/25646528346)）。対象テスト `サムネイル生成確認` は **18.6s で pass**
- [x] E2Eテストが通過（`npm run test:all-e2e` 等） — 該当範囲（API E2E）のみ。Frontend E2E / Chat Agent E2E は deploy ワークフローでは `test_suite: api` 指定のため未実行（本変更は API テストファイル単独修正のため影響なし）
- [ ] Chat Agent APIテストが通過（対象外）
- [x] 手動テスト完了 — staging 自動デプロイ後の post-deploy E2E（API Tests）が CI 上で完走

## ドキュメント更新確認

- [x] 上記いずれにも該当しない（テスト待機時間の調整のみ。新コマンド/新API/新依存いずれも未追加）

## 補足: 根本対応について

実装読みのみでは `image/jpeg` が返る経路を確定できなかった（CloudFront は uploadBucket を経由していないため当初仮説のキャッシュ汚染は反証）。本 PR は暫定対応であり、根本対応として **`thumbnailUrl` が `/thumbnails/` を含むまで polling** する方式を issue #82 で別途検討する。

production での flakiness 解消の最終確認は **次回 dev → main リリース後の production post-deploy E2E** で観測する。

## 関連Issue

Refs #82