### PR TITLE
fix(frontend): RuleEditor の名前入力に label[for]/input[id] を関連付け

### DIFF
--- a/frontend/src/components/settings/RuleEditor.vue
+++ b/frontend/src/components/settings/RuleEditor.vue
@@ -143,8 +143,9 @@ function onTestSend() {
     </h2>
 
     <div>
-      <label class="block text-xs text-gray-600 mb-1">ルール名（最大100字）</label>
+      <label for="rule-name-input" class="block text-xs text-gray-600 mb-1">ルール名（最大100字）</label>
       <input
+        id="rule-name-input"
         v-model="name"
         type="text"
         maxlength="100"


### PR DESCRIPTION
## 概要

PR #85 マージ後の staging E2E (`settings.spec.ts`) で、 「+ 新規作成」後の `getByLabel('ルール名（最大100字）')` が timeout していた。 原因は `<label>` と `<input>` の `for`/`id` 関連付けが無く、 Playwright がアクセシビリティ経由で input を取得できなかったため。

## 修正

```diff
- <label class="...">ルール名（最大100字）</label>
- <input v-model="name" type="text" maxlength="100" ... >
+ <label for="rule-name-input" class="...">ルール名（最大100字）</label>
+ <input id="rule-name-input" v-model="name" type="text" maxlength="100" ... >
```

副次的にアクセシビリティも改善（スクリーンリーダー対応）。

## 検証履歴

- 修正前 staging E2E `settings.spec.ts`: 6件中 5件失敗
- staging DDB `--overwrite` 後 再実行: 6件中 3件失敗（残3件は label 問題）
- 本修正で全 6件 PASS の見込み

## 関連

- issue #9
- PR #85（マージ済み）
- staging Frontend E2E run: https://github.com/ikeom-je/image-composite-agent/actions/runs/25709820580