### PR TITLE
fix(test): rules.api.spec.ts のプリセット name 期待値を新 name に整合

### DIFF
--- a/test/e2e/rules.api.spec.ts
+++ b/test/e2e/rules.api.spec.ts
@@ -47,16 +47,16 @@ test.describe('Rules API テスト', () => {
   // ===== 一覧・デフォルトルール =====
 
   test.describe('GET /chat/rules', () => {
-    test('AC 2.1 / 6.1 / 6.2: デフォルトルール（JAA）が含まれる', async () => {
+    test('AC 2.1 / 6.1 / 6.2: プリセットルールが含まれる', async () => {
       const res = await api.get(`${TEST_CONFIG.chatApiUrl}/rules`)
       expect(res.status()).toBe(200)
       const body = await res.json()
       expect(Array.isArray(body.rules)).toBe(true)
       expect(body.rules.length).toBeGreaterThan(0)
-      const jaa = body.rules.find((r: any) => r.ruleId === DEFAULT_RULE_ID)
-      expect(jaa, 'デフォルトルールが存在すること').toBeDefined()
-      expect(jaa.isDefault).toBe(true)
-      expect(jaa.name).toContain('JAA')
+      const preset = body.rules.find((r: any) => r.ruleId === DEFAULT_RULE_ID)
+      expect(preset, 'デフォルトルールが存在すること').toBeDefined()
+      expect(preset.isDefault).toBe(true)
+      expect(preset.name).toMatch(/字幕|テロップ|業界標準/)
     })
   })
 


### PR DESCRIPTION
## 概要

PR #85 改修-2（権利配慮で seed の name を「業界標準 字幕・テロップ配置規定」に変更）の **テストコード側更新漏れ**。 `test/e2e/rules.api.spec.ts:59` で旧 name `'JAA'` を期待していたため、 staging E2E API Tests が失敗していた。

## 修正

```diff
- test('AC 2.1 / 6.1 / 6.2: デフォルトルール（JAA）が含まれる', ...)
+ test('AC 2.1 / 6.1 / 6.2: プリセットルールが含まれる', ...)

- const jaa = body.rules.find((r) => r.ruleId === DEFAULT_RULE_ID)
- expect(jaa.name).toContain('JAA')
+ const preset = body.rules.find((r) => r.ruleId === DEFAULT_RULE_ID)
+ expect(preset.name).toMatch(/字幕|テロップ|業界標準/)
```

正規表現で柔軟に判定し、 将来の表示名変更にも追従可能。

## 検証履歴

- PR #85 マージ後 staging API E2E: 108件全PASS（DDB に旧 name `JAA字幕ハンドブック準拠 配置規定` が残っていたため偶然 PASS）
- staging DDB `--overwrite` 後 API E2E: AC 2.1 が失敗（新 name `業界標準 字幕・テロップ配置規定` に変更されたため）
- 本修正後: AC 2.1 が PASS する見込み

## 関連

- issue #9
- PR #85（マージ済み）
- PR #88（label 関連付け修正、 マージ済み）