### PR TITLE
fix(test): settings.spec.ts strict mode violation 修正

### DIFF
--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -33,13 +33,13 @@ test.describe('Settings ルール管理 UI', () => {
 
   test('AC 10.x: 新規作成 → 保存 → 一覧に反映', async ({ page }) => {
     await page.getByRole('button', { name: 'ルール（System Prompt）' }).click()
-    await page.getByText(PRESET_RULE_NAME).waitFor({ timeout: 10000 })
+    await page.getByText(PRESET_RULE_NAME).first().waitFor({ timeout: 10000 })
 
     await page.getByRole('button', { name: '+ 新規作成' }).click()
     const ruleName = `e2e-ui-${Date.now()}`
     await page.getByLabel('ルール名（最大100字）').fill(ruleName)
     await page.locator('textarea').first().fill('## E2Eテスト本文\n- 項目1')
-    await page.getByRole('button', { name: '保存' }).click()
+    await page.getByRole('button', { name: '保存', exact: true }).click()
     await expect(page.getByText(ruleName)).toBeVisible({ timeout: 10000 })
   })
 
@@ -48,7 +48,7 @@ test.describe('Settings ルール管理 UI', () => {
     await page.getByRole('button', { name: '+ 新規作成' }).click()
     await page.getByLabel('ルール名（最大100字）').fill('oversize')
     await page.locator('textarea').first().fill('a'.repeat(10001))
-    await expect(page.getByRole('button', { name: '保存' })).toBeDisabled()
+    await expect(page.getByRole('button', { name: '保存', exact: true })).toBeDisabled()
     await expect(page.getByText('上限超過')).toBeVisible()
   })
 


### PR DESCRIPTION
## 修正

Playwright `getByRole('button', { name: '保存' })` は **substring 検索がデフォルト** で、 「保存せずに試す」「保存中...」にも hit して strict mode violation を発生させていた。 `exact: true` を加えて完全一致に。

同じく `getByText(PRESET_RULE_NAME)` が複数要素（一覧 + 編集中ルール、 既存テスト残物など）に hit する場面で `.first()` を追加。

```diff
- await page.getByText(PRESET_RULE_NAME).waitFor({ timeout: 10000 })
+ await page.getByText(PRESET_RULE_NAME).first().waitFor({ timeout: 10000 })

- await page.getByRole('button', { name: '保存' }).click()
+ await page.getByRole('button', { name: '保存', exact: true }).click()

- await expect(page.getByRole('button', { name: '保存' })).toBeDisabled()
+ await expect(page.getByRole('button', { name: '保存', exact: true })).toBeDisabled()
```

## 検証履歴

- PR #89 反映後 Frontend E2E: 6件中 4 PASS / 2 FAIL（strict mode violation）
- 本修正後: 6件全 PASS の見込み

## 関連

- issue #9
- PR #85（マージ済み）/ PR #88（label修正）/ PR #89（テスト期待値修正）