### PR TITLE
fix(config): APIDemo の test 画像選択時 404 を修正（s3BucketNames.testImages 注入）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,11 +207,13 @@ jobs:
             --query "Stacks[0].Outputs[?OutputKey=='UploadApiUrl'].OutputValue" --output text 2>/dev/null || echo "")
           CHAT_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" --output text 2>/dev/null || echo "")
+          TEST_IMAGES_BUCKET=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='TestImagesBucketName'].OutputValue" --output text 2>/dev/null || echo "")
           VERSION=$(node -p "require('./package.json').version")
           BUILD_HASH=${GITHUB_SHA::7}
           DEBUG=$( [ "$ENV_NAME" = "production" ] && echo "false" || echo "true" )
           cat > frontend/public/config.json <<EOF
-          {"apiUrl":"${API_URL}","uploadApiUrl":"${UPLOAD_URL}","chatApiUrl":"${CHAT_URL}","cloudfrontUrl":"","version":"${VERSION}","buildHash":"${BUILD_HASH}","environment":"${ENV_NAME}","buildTimestamp":"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)","region":"${{ env.AWS_REGION }}","features":{"enableS3Upload":true,"enable3ImageComposition":true,"enableDebugMode":${DEBUG},"enableAnalytics":true,"enableCaching":true,"enableErrorReporting":true}}
+          {"apiUrl":"${API_URL}","uploadApiUrl":"${UPLOAD_URL}","chatApiUrl":"${CHAT_URL}","cloudfrontUrl":"","version":"${VERSION}","buildHash":"${BUILD_HASH}","environment":"${ENV_NAME}","buildTimestamp":"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)","region":"${{ env.AWS_REGION }}","s3BucketNames":{"testImages":"${TEST_IMAGES_BUCKET}"},"features":{"enableS3Upload":true,"enable3ImageComposition":true,"enableDebugMode":${DEBUG},"enableAnalytics":true,"enableCaching":true,"enableErrorReporting":true}}
           EOF
 
       - name: Build frontend

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -55,13 +55,15 @@ update_lambda_cloudfront_domain() {
 # バックエンドスタックの出力からconfig.jsonを生成
 generate_config() {
   echo "📝 config.json 生成中..."
-  local API_URL UPLOAD_URL CHAT_URL CF_DOMAIN
+  local API_URL UPLOAD_URL CHAT_URL CF_DOMAIN TEST_IMAGES_BUCKET
   API_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
     --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" --output text 2>/dev/null || echo "")
   UPLOAD_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
     --query "Stacks[0].Outputs[?OutputKey=='UploadApiUrl'].OutputValue" --output text 2>/dev/null || echo "")
   CHAT_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
     --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" --output text 2>/dev/null || echo "")
+  TEST_IMAGES_BUCKET=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
+    --query "Stacks[0].Outputs[?OutputKey=='TestImagesBucketName'].OutputValue" --output text 2>/dev/null || echo "")
   CF_DOMAIN=$(aws cloudformation describe-stacks --stack-name "$FRONT_STACK" \
     --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" --output text 2>/dev/null || echo "")
 
@@ -86,6 +88,9 @@ generate_config() {
   "environment": "${ENV}",
   "buildTimestamp": "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)",
   "region": "$(aws configure get region 2>/dev/null || echo 'ap-northeast-1')",
+  "s3BucketNames": {
+    "testImages": "${TEST_IMAGES_BUCKET}"
+  },
   "features": {
     "enableS3Upload": true,
     "enable3ImageComposition": true,


### PR DESCRIPTION
## Summary

- APIDemo でテスト画像アセット（circle/rectangle/triangle）を image2 に選択 → 合成実行で **404** が返る不具合を修正
- `frontend/public/config.json` に欠落していた `s3BucketNames.testImages` フィールドを CICD と `scripts/deploy.sh` の両方で生成するよう追加

## 不具合の根本原因

1. `frontend/src/components/ImageSelector.vue:225` で `const testBucket = config?.s3BucketNames?.testImages || 'test-bucket'`
2. config.json に `s3BucketNames` キー自体が無いため fallback の literal `'test-bucket'` を使用
3. 結果 `s3://test-bucket/images/rectangle_blue.png` を Lambda に POST
4. Lambda の `image_fetcher.py` が存在しないバケットを fetch 失敗 → `error_handler.py:369` で **S3_ERROR を 404** にマップして返却

## 修正内容

| ファイル | 変更 |
|---|---|
| `.github/workflows/deploy.yml` | CloudFormation Output `TestImagesBucketName` を query し config.json に `s3BucketNames.testImages` を追加 |
| `scripts/deploy.sh` | ローカル deploy 用にも同じ修正 |

`TestImagesBucketName` Output は `lib/image-processor-api-stack.ts:1201` で既に定義済み。

## 性質

PR #81 のレビューで顕在化したが、**v3.2.2 から存在する preexisting bug**。Lambda 側・CDK 側の変更は不要、設定生成スクリプトのみの修正で完結。

## Test plan

- [ ] CICD で dev → staging に自動デプロイ完了
- [ ] staging の https://d2p5wd0anahgvn.cloudfront.net/config.json に `s3BucketNames.testImages` が含まれる
- [ ] staging UI で APIDemo → image2 に「rectangle」選択 → 「画像を生成」で 200 OK / 合成画像表示
- [ ] image1 のみの単独合成も既存通り動作（既存パス回帰なし）

## 後続

このPRをマージ後、release/v3.3.0 にも取り込み（merge または cherry-pick）→ PR #81 を再レビュー → v3.3.0 リリース。

🤖 Generated with [Claude Code](https://claude.com/claude-code)