### PR TITLE
test(e2e): APIDemo shape画像選択の regression テスト追加（PR #91 関連）

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -57,6 +57,7 @@ jobs:
       api_url: ${{ steps.urls.outputs.api_url }}
       frontend_url: ${{ steps.urls.outputs.frontend_url }}
       chat_api_url: ${{ steps.urls.outputs.chat_api_url }}
+      test_images_bucket: ${{ steps.urls.outputs.test_images_bucket }}
     steps:
       - id: resolve
         run: |
@@ -92,14 +93,19 @@ jobs:
           CHAT_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" \
             --output text 2>/dev/null || echo "")
+          TEST_IMAGES_BUCKET=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='TestImagesBucketName'].OutputValue" \
+            --output text 2>/dev/null || echo "")
 
           echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
           echo "frontend_url=$FRONTEND_URL" >> "$GITHUB_OUTPUT"
           echo "chat_api_url=$CHAT_URL" >> "$GITHUB_OUTPUT"
+          echo "test_images_bucket=$TEST_IMAGES_BUCKET" >> "$GITHUB_OUTPUT"
 
           echo "API_URL: $API_URL"
           echo "FRONTEND_URL: $FRONTEND_URL"
           echo "CHAT_API_URL: $CHAT_URL"
+          echo "TEST_IMAGES_BUCKET: $TEST_IMAGES_BUCKET"
 
   # -------------------------------------------------------
   # 2. API統合テスト（Playwright）
@@ -130,6 +136,7 @@ jobs:
         run: npx playwright test --config=test/playwright-api.config.ts --project=api-tests --reporter=list
         env:
           API_URL: ${{ needs.resolve-env.outputs.api_url }}
+          TEST_IMAGES_BUCKET: ${{ needs.resolve-env.outputs.test_images_bucket }}
           CI: true
 
       - name: Upload test results
@@ -177,6 +184,7 @@ jobs:
         env:
           API_URL: ${{ needs.resolve-env.outputs.api_url }}
           FRONTEND_URL: ${{ needs.resolve-env.outputs.frontend_url }}
+          TEST_IMAGES_BUCKET: ${{ needs.resolve-env.outputs.test_images_bucket }}
           CI: true
 
       - name: Upload test results

--- a/test/e2e/image-selection-comprehensive.api.spec.ts
+++ b/test/e2e/image-selection-comprehensive.api.spec.ts
@@ -8,6 +8,9 @@ import { test, expect } from '@playwright/test';
 // API_URLは /images/composite パス込みの完全URL
 const API_COMPOSITE_URL = process.env.API_URL || 'http://localhost:3000/images/composite';
 const UPLOAD_API_URL = process.env.UPLOAD_API_URL || API_COMPOSITE_URL.replace('/images/composite', '/upload');
+// フロントが ImageSelector.vue から組み立てる shape 画像 s3:// パスの regression テスト用。
+// CFN Output TestImagesBucketName を deploy.yml / e2e-test.yml が env として渡す。
+const TEST_IMAGES_BUCKET = process.env.TEST_IMAGES_BUCKET || '';
 
 test.describe('画像選択機能包括テスト', () => {
   
@@ -93,7 +96,7 @@ test.describe('画像選択機能包括テスト', () => {
     expect(response1.status()).toBe(200);
     console.log('✓ 1画像モード: 正常');
 
-    // 2画像モード
+    // 2画像モード（両方とも Lambda shorthand 'test' なので必ず 200）
     const response2 = await request.get(`${API_COMPOSITE_URL}`, {
       params: {
         ...baseParams,
@@ -110,7 +113,7 @@ test.describe('画像選択機能包括テスト', () => {
       }
     });
 
-    expect([200, 403, 404]).toContain(response2.status());
+    expect(response2.status()).toBe(200);
     console.log('✓ 2画像モード: 正常');
 
     // 3画像モード
@@ -271,6 +274,71 @@ test.describe('画像選択機能包括テスト', () => {
       
       console.log(`✓ ${selection.description} (${selection.type}): パス設定正常`);
     }
+  });
+
+  // PR #91 regression: フロント ImageSelector.vue が組み立てる shape 画像 s3:// パスを
+  // 直接 API に投げて 200 を期待する。config.json の s3BucketNames.testImages 欠落で
+  // 旧 fallback `s3://test-bucket/...` に落ちると 404 になる回帰を検知する。
+  test('shape テスト画像（circle / rectangle / triangle）の s3:// パス合成', async ({ request }) => {
+    test.skip(!TEST_IMAGES_BUCKET, 'TEST_IMAGES_BUCKET env 未設定のためスキップ');
+
+    const shapes: Array<{ name: string; file: string }> = [
+      { name: 'circle', file: 'circle_red.png' },
+      { name: 'rectangle', file: 'rectangle_blue.png' },
+      { name: 'triangle', file: 'triangle_green.png' },
+    ];
+
+    for (const shape of shapes) {
+      const s3Path = `s3://${TEST_IMAGES_BUCKET}/images/${shape.file}`;
+      const response = await request.get(`${API_COMPOSITE_URL}`, {
+        params: {
+          baseImage: 'transparent',
+          image1: 'test',
+          image1X: '100',
+          image1Y: '100',
+          image1Width: '400',
+          image1Height: '300',
+          image2: s3Path,
+          image2X: '600',
+          image2Y: '100',
+          image2Width: '400',
+          image2Height: '300',
+          canvasWidth: '1920',
+          canvasHeight: '1080',
+          format: 'png',
+        },
+      });
+
+      expect(response.status()).toBe(200);
+      expect(response.headers()['content-type']).toContain('image/png');
+      console.log(`✓ ${shape.name} (${s3Path}): 200 OK`);
+    }
+  });
+
+  // PR #91 regression: 旧バグ条件（config 欠落時の fallback 'test-bucket'）を
+  // 直接再現し 404 が返ることを確認する。修正が将来逆戻りした場合に検知できる。
+  test('旧 fallback `s3://test-bucket/...` は 404 を返す（regression 確認）', async ({ request }) => {
+    const response = await request.get(`${API_COMPOSITE_URL}`, {
+      params: {
+        baseImage: 'transparent',
+        image1: 'test',
+        image1X: '100',
+        image1Y: '100',
+        image1Width: '400',
+        image1Height: '300',
+        image2: 's3://test-bucket/images/circle_red.png',
+        image2X: '600',
+        image2Y: '100',
+        image2Width: '400',
+        image2Height: '300',
+        canvasWidth: '1920',
+        canvasHeight: '1080',
+        format: 'png',
+      },
+    });
+
+    expect(response.status()).toBe(404);
+    console.log('✓ 旧 fallback bucket: 404 を確実に返す');
   });
 
   test('未選択状態のエラーハンドリング', async ({ request }) => {

--- a/test/e2e/image-selection.spec.ts
+++ b/test/e2e/image-selection.spec.ts
@@ -42,6 +42,37 @@ test.describe('画像選択・モード切替（/api ページ）', () => {
     await expect(generateButton).toContainText('3画像を合成');
   });
 
+  // PR #91 regression: image2 セレクタで shape テスト画像（circle/rectangle/triangle）を
+  // 選んで合成ボタンを押した時、composite API が 200 を返すこと。
+  // config.json の s3BucketNames.testImages が欠落すると ImageSelector.vue が
+  // 旧 fallback `s3://test-bucket/...` を組み立てて 404 になる回帰を検知する。
+  test('image2 で shape テスト画像を選択して合成→ composite API は 200', async ({ page }) => {
+    const modeButtons = page.locator('.mode-buttons button');
+    await modeButtons.filter({ hasText: '2画像' }).click();
+    await expect(modeButtons.filter({ hasText: '2画像' })).toHaveClass(/active/);
+
+    const image2Select = page.locator('td.image2-cell select.form-select-compact');
+    await expect(image2Select).toBeVisible();
+    await image2Select.selectOption('triangle');
+    await expect(image2Select).toHaveValue('triangle');
+
+    // baseURL は FRONTEND_URL のため、CloudFront ではなく API Gateway を直接叩く。
+    // URL 一致は path のみで判定（環境別 API ホストに左右されない）。
+    const compositePromise = page.waitForResponse(
+      (resp) => resp.url().includes('/images/composite') && resp.request().method() === 'GET',
+      { timeout: 20000 },
+    );
+    await page.locator('button.generate-button').click();
+    const response = await compositePromise;
+
+    expect(response.status()).toBe(200);
+    const image2Param = new URL(response.url()).searchParams.get('image2') || '';
+    expect(image2Param.startsWith('s3://')).toBe(true);
+    expect(image2Param).toContain('triangle_green.png');
+    // 旧 fallback `test-bucket` でないこと
+    expect(image2Param).not.toContain('s3://test-bucket/');
+  });
+
   test('数値入力フィールドが正しく動作する', async ({ page }) => {
     // 位置・サイズ設定テーブル内の number input
     const numberInputs = page.locator('table.config-table input[type="number"]');


### PR DESCRIPTION
## Summary

PR #91 で修正した「APIDemo の test 画像（circle/rectangle/triangle）選択時に 404 が返るバグ」を、E2E が検知できなかった盲点を埋めるための regression テスト追加。

### 何故 E2E をすり抜けたか
- **UI E2E (`image-selection.spec.ts`)**: テスト画像プルダウンを開いて circle/rectangle/triangle を選ぶフローそのものが未テスト（モード切替・テーブル表示・数値入力のみ）
- **API E2E (`image-selection-comprehensive.api.spec.ts`)**: `testImageTypes = ['test']` のみ。Lambda の `'test'` ショートカットだけ叩き、フロントが組み立てる `s3://${testBucket}/images/circle_red.png` という具体パスは未テスト
- 同 API E2E line 113 の 2画像モード assertion が `expect([200, 403, 404]).toContain(...)` と緩く、**404 を成功扱い**していた

## 変更内容

### API E2E (`test/e2e/image-selection-comprehensive.api.spec.ts`)
- 2画像モード assertion を strict `toBe(200)` に変更
- 新規ケース: `s3://${TEST_IMAGES_BUCKET}/images/{circle_red,rectangle_blue,triangle_green}.png` を直接叩いて 200 を期待
- 新規ケース: 旧 fallback `s3://test-bucket/...` で 404 を返すことを確認（修正が逆戻りした場合の検知）

### UI E2E (`test/e2e/image-selection.spec.ts`)
- `/api` ページで image2 セレクタを `triangle` に切り替え → 合成ボタン → composite API が 200 + URL に `triangle_green.png` を含む + 旧 fallback `s3://test-bucket/` を含まないことを検証

### ワークフロー (`.github/workflows/e2e-test.yml`)
- `resolve-env` で CFN Output `TestImagesBucketName` を取得し、`api-tests` / `frontend-tests` ジョブに `TEST_IMAGES_BUCKET` env として伝播

## Test plan

ローカルで staging に対して以下を実行済み（chromium はホスト依存のため UI は CI 検証）:

- [x] API E2E shape regression: 3 tests passed (circle/rectangle/triangle 全て 200)
- [x] API E2E 旧 fallback regression: pass (404 を確実に返す)
- [x] API E2E 1画像・2画像・3画像モード strict assertion: pass
- [x] `playwright test --list` で UI 新ケース認識を確認
- [ ] CI: `frontend-tests` ジョブで UI 新ケースが pass する（マージ後 staging に対する E2E ワークフロー手動 dispatch で確認）

## 関連 PR
- #81 (v3.3.0 release, 元のレビューでバグ発見)
- #91 (config.json への `s3BucketNames.testImages` 注入で修正)

🤖 Generated with [Claude Code](https://claude.com/claude-code)