### PR TITLE
fix(chat): Chat 画面に /chat/settings 遷移ボタン追加 + ナビゲーション E2E

### DIFF
--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -29,6 +29,16 @@
         >
           履歴クリア
         </button>
+        <router-link
+          to="/chat/settings"
+          aria-label="Agent設定"
+          title="Agent設定"
+          class="inline-flex items-center justify-center w-8 h-8 text-gray-500 bg-gray-100 rounded hover:bg-gray-200 hover:text-gray-700 transition-colors"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+          </svg>
+        </router-link>
       </div>
     </div>
 

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -77,3 +77,54 @@ test.describe('Settings ルール管理 UI', () => {
     await expect(presetCard.getByRole('button', { name: '削除' })).toHaveCount(0)
   })
 })
+
+// PR #81 動作レビューで判明した課題に対応する追加テスト:
+// Chat 画面から /chat/settings への遷移ボタンが UI 上に存在しないため、
+// 設定画面への到達手段が URL 直打ちのみだった。本テストでは ChatPage に
+// 追加した歯車ボタンを経由した正規ルートでの「画面遷移 + 設定反映」を検証する。
+test.describe('Chat ↔ Settings 画面遷移と設定反映', () => {
+  test.beforeEach(async ({ page }) => {
+    if (!FRONTEND_URL) test.skip()
+    await page.goto(`${FRONTEND_URL}/`)
+    await page.evaluate(() => localStorage.removeItem('chat-pending-test-rule'))
+  })
+
+  test('/chat の設定ボタン押下で /chat/settings に遷移する', async ({ page }) => {
+    await page.goto(`${FRONTEND_URL}/chat`)
+    await expect(page).toHaveURL(/\/chat$/)
+
+    const settingsLink = page.getByRole('link', { name: 'Agent設定' })
+    await expect(settingsLink).toBeVisible()
+    await settingsLink.click()
+
+    await expect(page).toHaveURL(/\/chat\/settings$/)
+    await expect(page.getByRole('heading', { name: 'Agent 設定' })).toBeVisible()
+  })
+
+  test('Chat→Settings→ルール作成→戻る→再度Settingsで保存内容が反映される', async ({ page }) => {
+    // 1) /chat から設定ボタンで遷移
+    await page.goto(`${FRONTEND_URL}/chat`)
+    await page.getByRole('link', { name: 'Agent設定' }).click()
+    await expect(page).toHaveURL(/\/chat\/settings$/)
+
+    // 2) ルールタブ → 新規作成 → 保存
+    await page.getByRole('button', { name: 'ルール（System Prompt）' }).click()
+    await page.getByText(PRESET_RULE_NAME).first().waitFor({ timeout: 10000 })
+    await page.getByRole('button', { name: '+ 新規作成' }).click()
+    const ruleName = `e2e-nav-${Date.now()}`
+    await page.getByLabel('ルール名（最大100字）').fill(ruleName)
+    await page.locator('textarea').first().fill('## ナビゲーションE2E本文\n- 項目1')
+    await page.getByRole('button', { name: '保存', exact: true }).click()
+    await expect(page.getByText(ruleName)).toBeVisible({ timeout: 10000 })
+
+    // 3) SettingsPage の戻る矢印で /chat に戻る
+    await page.locator('a[href="/chat"]').first().click()
+    await expect(page).toHaveURL(/\/chat$/)
+
+    // 4) 再度 /chat の設定ボタンで /chat/settings に戻り、ルールタブで保存内容が残ること
+    await page.getByRole('link', { name: 'Agent設定' }).click()
+    await expect(page).toHaveURL(/\/chat\/settings$/)
+    await page.getByRole('button', { name: 'ルール（System Prompt）' }).click()
+    await expect(page.getByText(ruleName)).toBeVisible({ timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## Summary

PR #81 の動作レビューで判明した課題に対応。

### 課題
- ChatPage には `/chat/settings` への遷移ボタンが UI 上に存在せず、URL 直打ち以外で設定画面に辿り着けない（`/api` ページから戻ったときに気付けない）
- `settings.spec.ts` は `page.goto('/chat/settings')` で直接ジャンプしていたため、UI ナビゲーションの存在を検証できていなかった
- 双方向のうち SettingsPage → /chat の戻り矢印は既にあったが、Chat → Settings が片道で欠落

## 変更内容

### ChatPage.vue（`frontend/src/pages/ChatPage.vue`）
- ヘッダー右上、「履歴クリア」ボタンの右隣に歯車アイコンの router-link を追加
- `to="/chat/settings"` / `aria-label="Agent設定"` / `title="Agent設定"`
- 既存ボタンと統一感のあるスタイル（`w-8 h-8` の gray ボックス + 歯車 SVG）

### settings.spec.ts（`test/e2e/settings.spec.ts`）
新規 describe `Chat ↔ Settings 画面遷移と設定反映`:
- `/chat の設定ボタン押下で /chat/settings に遷移する` — 正規ルートの遷移検証
- `Chat→Settings→ルール作成→戻る→再度Settingsで保存内容が反映される` — 画面遷移 + 設定反映のユースケース全体を end-to-end で検証

## Test plan

- [x] `playwright test --list` で新規 2 ケース認識を確認（settings-tests project, 計 8 件）
- [ ] CI Frontend Build & Lint（router-link / Tailwind 検証）
- [ ] マージ後、staging で `test_suite: frontend` の E2E を手動 dispatch して selection-tests + settings-tests が pass することを確認

## 進め方
レビューコメント通り `dev → release/v3.3.0 → main` の順で反映:
1. 本 PR を dev にマージ
2. release/v3.3.0 に dev 取込
3. PR #81 の CI 再走 → main マージ

## 関連
- PR #81 (release/v3.3.0 → main)
- PR #91 (config 修正)
- PR #92 (shape regression テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)