### PR TITLE
fix(test): shape画像選択 E2E の toHaveValue assertion 削除

### DIFF
--- a/test/e2e/image-selection.spec.ts
+++ b/test/e2e/image-selection.spec.ts
@@ -54,7 +54,11 @@ test.describe('画像選択・モード切替（/api ページ）', () => {
     const image2Select = page.locator('td.image2-cell select.form-select-compact');
     await expect(image2Select).toBeVisible();
     await image2Select.selectOption('triangle');
-    await expect(image2Select).toHaveValue('triangle');
+    // triangle 選択後、ImageSelector.vue は s3:// パスを emit し
+    // selectedS3ImageDisplay computed が新たな option を追加するため、
+    // select の HTML value は最終的に s3:// パス全文になる（実装仕様）。
+    // 本テストの目的は「フロントが正しい s3:// パスを組み立てて合成 API が 200 を返す」
+    // ことなので、select の内部値は検証せず、composite レスポンス URL の image2 パラメータで検証する。
 
     // baseURL は FRONTEND_URL のため、CloudFront ではなく API Gateway を直接叩く。
     // URL 一致は path のみで判定（環境別 API ホストに左右されない）。


### PR DESCRIPTION
## Summary

PR #92 で追加した `image-selection.spec.ts:49 shape regression test` が staging frontend E2E で fail していた問題の修正。

## 原因

`await expect(image2Select).toHaveValue('triangle')` が 5000ms タイムアウト（3 retry 全て）。
ImageSelector.vue は triangle 選択時に `s3://<bucket>/images/triangle_green.png` を emit し、`selectedS3ImageDisplay` computed が新たな option (value=s3:// path、`selected` 属性付き) を追加するため、**select の HTML value は最終的に s3:// パス全文**になる仕様。これは実装詳細であり、テストの本質と外れていた。

PR #92 時点では ARM Pi で chromium が動かず、実環境での UI 動作確認なしに assertion を入れたのが原因。

## 修正

`toHaveValue('triangle')` 行を削除し、その下の **composite レスポンス URL 検証**（image2 パラメータが `triangle_green.png` を含む / 旧 fallback `s3://test-bucket` でない）に検証責務を集約。

機能としての回帰検知（フロントが正しい s3:// パスを組み立てる）は composite API レスポンスの URL 内容で完全に担保される。

## Test plan

- [x] 該当行のみ削除（差分 +5 / -1）
- [ ] CI Frontend Build & Lint pass
- [ ] マージ後 staging frontend E2E 手動 dispatch で shape regression が pass

## 進め方

選択肢 A（修正先 dev → release/v3.3.0 取込先）に従う:
1. 本 PR を dev にマージ
2. staging frontend E2E 確認
3. release/v3.3.0 に dev 取込
4. PR #81 の CI 再走 → main マージ

## 関連
- PR #92 (shape regression テスト追加。本修正対象)
- PR #81 (release/v3.3.0 → main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)