### PR TITLE
fix(test): staging frontend E2E の偽 fail を解消 (POST method + selector narrowing)

### DIFF
--- a/test/e2e/image-selection.spec.ts
+++ b/test/e2e/image-selection.spec.ts
@@ -58,19 +58,19 @@ test.describe('画像選択・モード切替（/api ページ）', () => {
     // selectedS3ImageDisplay computed が新たな option を追加するため、
     // select の HTML value は最終的に s3:// パス全文になる（実装仕様）。
     // 本テストの目的は「フロントが正しい s3:// パスを組み立てて合成 API が 200 を返す」
-    // ことなので、select の内部値は検証せず、composite レスポンス URL の image2 パラメータで検証する。
+    // ことなので、select の内部値は検証せず、composite リクエスト body の image2 で検証する。
 
-    // baseURL は FRONTEND_URL のため、CloudFront ではなく API Gateway を直接叩く。
-    // URL 一致は path のみで判定（環境別 API ホストに左右されない）。
+    // App.vue:380 が axios.post で送るため method は POST、image2 は body 内。
     const compositePromise = page.waitForResponse(
-      (resp) => resp.url().includes('/images/composite') && resp.request().method() === 'GET',
+      (resp) => resp.url().includes('/images/composite') && resp.request().method() === 'POST',
       { timeout: 20000 },
     );
     await page.locator('button.generate-button').click();
     const response = await compositePromise;
 
     expect(response.status()).toBe(200);
-    const image2Param = new URL(response.url()).searchParams.get('image2') || '';
+    const body = response.request().postDataJSON();
+    const image2Param = String(body?.image2 ?? '');
     expect(image2Param.startsWith('s3://')).toBe(true);
     expect(image2Param).toContain('triangle_green.png');
     // 旧 fallback `test-bucket` でないこと

--- a/test/e2e/settings.spec.ts
+++ b/test/e2e/settings.spec.ts
@@ -72,7 +72,10 @@ test.describe('Settings ルール管理 UI', () => {
 
   test('AC 9.4: デフォルトルールには削除ボタンが表示されない', async ({ page }) => {
     await page.getByRole('button', { name: 'ルール（System Prompt）' }).click()
-    const presetCard = page.locator('div', { hasText: PRESET_RULE_NAME }).first()
+    // RuleListItem.vue は <div class="rounded-lg border p-4 ..."> を card root として描画する。
+    // 単に `div hasText` だと外側リストコンテナ全体にヒットし、他カードの削除ボタンが
+    // 残量に含まれて E2E rule 蓄積時に偽 fail を起こすため card 単位に narrowing する。
+    const presetCard = page.locator('div.rounded-lg', { hasText: PRESET_RULE_NAME }).first()
     await presetCard.waitFor({ timeout: 10000 })
     await expect(presetCard.getByRole('button', { name: '削除' })).toHaveCount(0)
   })


### PR DESCRIPTION
## Summary

PR #93 / #94 マージ後の staging frontend E2E で発生していた 2 件の偽 fail を修正。release/v3.3.0 取込前のブロッカー解消。

## 原因と修正

### 1. `image-selection.spec.ts:49` shape regression (PR #92 由来)
**原因**:
- filter が `request().method() === 'GET'` を期待していたが、`App.vue:380` は `axios.post(endpoint, compositeParams, ...)` で送信。
- `waitForResponse(20s)` がマッチせずタイムアウト（3 retry 全失敗）。
- 元の PR #92 では ARM Pi で chromium が動かず実環境検証なしでマージしてしまい、UI 経路で実行された最初の機会で顕在化。

**修正**:
- filter を POST に変更（`resp.request().method() === 'POST'`）
- 検証対象を URL `searchParams` から **POST body** `response.request().postDataJSON().image2` に変更
- これで「フロントが正しい s3:// パスを組み立てて合成 API が 200 を返す」という本来のテスト目的を実際に検証できる

### 2. `settings.spec.ts:73 AC 9.4 デフォルトルールには削除ボタンが表示されない`
**原因**:
- `page.locator('div', { hasText: PRESET_RULE_NAME }).first()` が外側のリストコンテナ全体にヒット。
- その内部に含まれる **他カードの削除ボタンもカウント対象**になり、E2E 蓄積で user rules が増えると顕在化（DDB 6 件中 5 件が `e2e-*` rule に成長していた）。

**修正**:
- `RuleListItem.vue` の card root クラス `rounded-lg` で narrowing:
  - 旧: `page.locator('div', { hasText: PRESET_RULE_NAME }).first()`
  - 新: `page.locator('div.rounded-lg', { hasText: PRESET_RULE_NAME }).first()`

### 補助対応（コード外）
staging DDB の蓄積 `e2e-ui-*` / `e2e-nav-*` rules 5 件を DELETE API で削除済み（即時アンブロック）。preset 1 件のみ残存。

## Test plan

- [x] ローカル `playwright test --list` で 2 ファイル × 影響箇所の test 認識を確認
- [ ] CI 4/4 pass
- [ ] マージ後、staging frontend E2E 手動 dispatch で 2 件とも pass を確認

## 進め方
1. 本 PR を dev にマージ
2. staging frontend E2E 確認 → 全 pass
3. release/v3.3.0 に dev 取込
4. PR #81 CI 再走 → main マージ

## 関連
- PR #81 (release/v3.3.0 → main)
- PR #92 (shape regression 元実装。本 PR で根本修正)
- PR #93 (Chat→Settings ナビボタン)
- PR #94 (toHaveValue 削除暫定対応。本 PR で完全修正に置き換え)

🤖 Generated with [Claude Code](https://claude.com/claude-code)