### PR TITLE
fix(test): issue #82 サムネイル E2E を fixed wait → polling 化

### DIFF
--- a/test/e2e/upload-comprehensive.api.spec.ts
+++ b/test/e2e/upload-comprehensive.api.spec.ts
@@ -68,6 +68,9 @@ test.describe('S3アップロード機能包括テスト', () => {
   });
 
   test('サムネイル生成確認', async ({ request }) => {
+    // poll 最大 30s + presigned/PUT/LIST のオーバーヘッドで config の 30s timeout を超える
+    // ため、test レベルで 60s に拡張する。
+    test.setTimeout(60000);
     // テスト用PNGをアップロード（既存S3データに依存しないよう自己完結）
     const presignedResponse = await request.post(`${UPLOAD_API_URL}/presigned-url`, {
       data: {
@@ -85,25 +88,44 @@ test.describe('S3アップロード機能包括テスト', () => {
     });
     expect(uploadResponse.status()).toBe(200);
 
-    // S3トリガー → Lambda によるサムネイル生成を待機
-    // 15s に拡張: production で稀にフォールバック URL（元画像）が返り content-type
-    // 不一致になる事象（issue #82）の暫定対応。Lambda コールドスタート + S3 整合性
-    // ウィンドウを吸収。根本対応（polling 化）は同 issue で別途検討。
-    await new Promise(resolve => setTimeout(resolve, 15000));
+    // issue #82: サムネイル URL の Content-Type を polling で検証。
+    //
+    // 実装の現状（CDK で S3 → Lambda 通知が未配線のため）:
+    //   - サムネイル生成 Lambda (`generate_thumbnail`) は一度も発火しない
+    //   - `list_uploaded_images()` は常に **元画像 (uploads/images/*) の presigned URL**
+    //     を fallback として返す
+    //   - 元画像は PUT 時に Content-Type=image/png を S3 メタデータに保存しているため、
+    //     通常は image/png を返す
+    //   - 過去 1 回だけ観測された image/jpeg は CloudFront TTL=10s 等の transient
+    //     なエッジ整合性事象と推定（issue #82 仮説 1）
+    //
+    // テスト方針:
+    //   - 旧: 固定 15s sleep（CloudFront の stale なキャッシュを引いた時に retry でも回復しない）
+    //   - 新: LIST に出現 + thumbnailUrl GET が image/png を返すまで最大 30s polling
+    //         （transient な image/jpeg が出ても次のサイクルで image/png に収束する想定）
+    //
+    // なお、サムネイル機能自体の CDK 配線漏れは別途 issue として切り出す。
+    let thumbnailUrl: string | undefined;
+    let thumbnailContentType: string | undefined;
+    await expect.poll(async () => {
+      const listResp = await request.get(`${UPLOAD_API_URL}/images`);
+      if (listResp.status() !== 200) return null;
+      const listData = await listResp.json();
+      const uploadedImage = listData.images.find((img: any) => img.key === presignedData.s3Key);
+      if (!uploadedImage?.thumbnailUrl) return null;
+      const thumbResp = await request.get(uploadedImage.thumbnailUrl);
+      if (thumbResp.status() !== 200) return null;
+      thumbnailUrl = uploadedImage.thumbnailUrl;
+      thumbnailContentType = thumbResp.headers()['content-type'];
+      return thumbnailContentType;
+    }, {
+      timeout: 30000,
+      intervals: [500, 1000, 1000, 2000, 2000, 3000, 5000, 5000, 5000],
+      message: 'サムネイル URL が image/png を返すまで polling（最大30s）',
+    }).toMatch(/image\/png/);
 
-    // アップロードした画像をキーで特定してサムネイルを確認
-    const listResponse = await request.get(`${UPLOAD_API_URL}/images`);
-    expect(listResponse.status()).toBe(200);
-
-    const listData = await listResponse.json();
-    const uploadedImage = listData.images.find((img: any) => img.key === presignedData.s3Key);
-    expect(uploadedImage).toBeDefined();
-    expect(uploadedImage).toHaveProperty('thumbnailUrl');
-    expect(uploadedImage.thumbnailUrl).toContain('amazonaws.com');
-
-    const thumbnailResponse = await request.get(uploadedImage.thumbnailUrl);
-    expect(thumbnailResponse.status()).toBe(200);
-    expect(thumbnailResponse.headers()['content-type']).toContain('image/png');
+    expect(thumbnailUrl).toContain('amazonaws.com');
+    expect(thumbnailContentType).toContain('image/png');
   });
 
   test('複数ファイル形式のサポート確認', async ({ request }) => {


### PR DESCRIPTION
Closes #82

## Summary

`test/e2e/upload-comprehensive.api.spec.ts:70 サムネイル生成確認` テストの flakiness を `expect.poll` ベースに書き換えて解消。staging 検証で **15s → 2.7s に短縮**、retry 不要で安定。

## 調査で判明した実装の現状（重要）

修正中に **CDK の構成ミス**が発覚。サムネイル機能の S3 → Lambda 通知 (`addEventNotification`) が CDK 側で**一切配線されていない**ため、`generate_thumbnail` Lambda は両環境（staging / production）で**一度も発火していない**。

**証拠**:
- staging upload bucket: 20 objects all in `uploads/` prefix、`thumbnails/` 不在
- production upload bucket: 22 objects all in `uploads/` prefix、`thumbnails/` 不在
- `aws s3api get-bucket-notification-configuration` 両環境とも空
- `grep addEventNotification lib/` 該当なし

**動作の現状**: `list_uploaded_images()` は常に**元画像 (uploads/images/*) の presigned URL** を fallback として返す。元画像は PUT 時に Content-Type を正しく `image/png` で保存している（実機 head-object で確認済み）ため、通常は image/png を返す。過去 1 回観測された image/jpeg は CloudFront TTL=10s 等の transient なエッジ整合性事象と推定（issue #82 仮説 1）。

サムネイル機能の CDK 配線漏れは本 PR スコープ外として、別途 issue で対応する。

## 変更内容

### `test/e2e/upload-comprehensive.api.spec.ts:70`
- 固定 `setTimeout(15000)` 削除
- `expect.poll` で「LIST に出現 + thumbnailUrl が image/png を返す」まで最大 30s 再試行
- interval: `[500, 1000, 1000, 2000, 2000, 3000, 5000, 5000, 5000]`（短く始めて指数的に長く）
- `test.setTimeout(60000)` で test 全体の余裕を確保（config 30s timeout より長く）

## Test plan

- [x] ローカル staging で単体テスト pass を確認（2.7s）
- [x] upload-comprehensive.api.spec.ts 全 9 件 pass 確認（合計 8s、旧版は最低 15s + α）
- [ ] CI 4/4 pass
- [ ] dev マージ後 staging API E2E 全 pass 確認

## 関連
- #82 (本 issue)
- v3.2.2 PR #80 / ca19519（自己完結化、本 issue では完全解消できなかった）

🤖 Generated with [Claude Code](https://claude.com/claude-code)