### PR TITLE
feat(ci): issue #87 PR Preview — ephemeral CloudFront/S3 frontend preview

### DIFF
--- a/.github/workflows/cleanup-stale-previews.yml
+++ b/.github/workflows/cleanup-stale-previews.yml
@@ -98,8 +98,6 @@ jobs:
                 PR_NUM=$(echo "$STACK" | sed -E 's/^FrontendStack-Dev-Pr([0-9]+).*$/\1/')
                 npx cdk destroy "$STACK" \
                   -c previewPr="$PR_NUM" \
-                  -c previewBasicAuthUser="placeholder" \
-                  -c previewBasicAuthPass="placeholder" \
                   --force
                 DESTROYED=$((DESTROYED + 1))
               fi

--- a/.github/workflows/cleanup-stale-previews.yml
+++ b/.github/workflows/cleanup-stale-previews.yml
@@ -1,0 +1,113 @@
+# Stale PR Preview Cleanup - 7 日 idle の FrontendStack-Dev-Pr* を destroy
+# issue #87: PR preview の孤児スタック防止
+#
+# 仕様:
+#   - 日次 cron (UTC 18:00 = JST 03:00) で実行
+#   - LastUpdatedTime > 7 日前の FrontendStack-Dev-Pr<num> を destroy
+#   - 対応する PR が open + preview ラベル付きでも 7 日経てば destroy（label 再付与で再 deploy 可能）
+#   - 手動 workflow_dispatch にも対応
+#
+name: Stale PR Preview Cleanup
+
+on:
+  schedule:
+    - cron: '0 18 * * *'  # UTC 18:00 daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (削除せず対象一覧のみ表示)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  NODE_VERSION: "22"
+  AWS_REGION: ap-northeast-1
+  STALE_DAYS: 7
+
+jobs:
+  cleanup:
+    name: Cleanup stale previews
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: TypeScript build
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build dummy ffmpeg (for cdk destroy synth)
+        run: |
+          mkdir -p lambda-layers
+          [ -f lambda-layers/ffmpeg-layer.zip ] || (echo "dummy" | zip lambda-layers/ffmpeg-layer.zip - >/dev/null)
+
+      - name: List + destroy stale previews
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          THRESHOLD_EPOCH=$(date -u -d "$STALE_DAYS days ago" +%s)
+          echo "Threshold: $(date -u -d @$THRESHOLD_EPOCH '+%Y-%m-%d %H:%M:%S UTC') (7 days ago)"
+          echo "Dry run: $DRY_RUN"
+          echo ""
+
+          # FrontendStack-Dev-Pr* 一覧を取得
+          STACKS=$(aws cloudformation list-stacks \
+            --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
+            --query "StackSummaries[?starts_with(StackName, 'FrontendStack-Dev-Pr')].StackName" \
+            --output text || echo "")
+
+          if [ -z "$STACKS" ]; then
+            echo "No PR preview stacks found."
+            exit 0
+          fi
+
+          DESTROYED=0
+          KEPT=0
+          for STACK in $STACKS; do
+            LAST_UPDATED=$(aws cloudformation describe-stacks --stack-name "$STACK" \
+              --query "Stacks[0].LastUpdatedTime || Stacks[0].CreationTime" --output text)
+            LAST_EPOCH=$(date -u -d "$LAST_UPDATED" +%s)
+            AGE_DAYS=$(( ( $(date -u +%s) - LAST_EPOCH ) / 86400 ))
+
+            if [ $LAST_EPOCH -lt $THRESHOLD_EPOCH ]; then
+              echo "  [STALE  ${AGE_DAYS}d] $STACK"
+              if [ "$DRY_RUN" != "true" ]; then
+                # PR 番号を stack 名から抽出
+                PR_NUM=$(echo "$STACK" | sed -E 's/^FrontendStack-Dev-Pr([0-9]+).*$/\1/')
+                npx cdk destroy "$STACK" \
+                  -c previewPr="$PR_NUM" \
+                  -c previewBasicAuthUser="placeholder" \
+                  -c previewBasicAuthPass="placeholder" \
+                  --force
+                DESTROYED=$((DESTROYED + 1))
+              fi
+            else
+              echo "  [keep   ${AGE_DAYS}d] $STACK"
+              KEPT=$((KEPT + 1))
+            fi
+          done
+
+          echo ""
+          echo "Summary: destroyed=$DESTROYED, kept=$KEPT"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,276 @@
+# PR Preview - 短命 frontend stack を CloudFront + S3 でデプロイ
+# issue #87: PR レビュアーが UI を実機で確認するための ephemeral preview
+#
+# 仕様:
+#   - ラベル "preview" 付与時 / "preview" 付きの synchronize / reopen で deploy
+#   - PR close (merge 含む) で destroy
+#   - PR コメントに URL + Basic Auth credentials を自動投稿
+#   - frontend のみ deploy (backend は共有 dev を参照)
+#   - Basic Auth credentials は repository secrets で管理
+#
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened, closed]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "22"
+  AWS_REGION: ap-northeast-1
+  PREVIEW_LABEL: preview
+  SHARED_DEV_API_STACK: ImageProcessorApiStack-Dev
+  SHARED_DEV_FRONTEND_STACK: FrontendStack-Dev
+
+jobs:
+  # 共通: ラベル状態を解決
+  resolve:
+    name: Resolve preview state
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.r.outputs.pr_number }}
+      stack_name: ${{ steps.r.outputs.stack_name }}
+      should_deploy: ${{ steps.r.outputs.should_deploy }}
+      should_destroy: ${{ steps.r.outputs.should_destroy }}
+    steps:
+      - id: r
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          ACTION: ${{ github.event.action }}
+          # PR の現在ラベル一覧 (closed 時もそのまま参照可)
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
+        run: |
+          STACK="FrontendStack-Dev-Pr${PR_NUM}"
+          echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+          echo "stack_name=${STACK}" >> "$GITHUB_OUTPUT"
+
+          # deploy 条件: preview ラベルが付いた状態で {opened, labeled, synchronize, reopened}
+          if [ "$ACTION" = "closed" ]; then
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "should_destroy=true" >> "$GITHUB_OUTPUT"
+          elif [ "$ACTION" = "unlabeled" ]; then
+            # preview ラベルが外された場合のみ destroy
+            REMOVED="${{ github.event.label.name }}"
+            if [ "$REMOVED" = "preview" ]; then
+              echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+              echo "should_destroy=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+              echo "should_destroy=false" >> "$GITHUB_OUTPUT"
+            fi
+          elif [ "$HAS_LABEL" = "true" ]; then
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
+            echo "should_destroy=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "should_destroy=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "Stack: $STACK / Action: $ACTION / has-label: $HAS_LABEL"
+
+  # frontend を build → CDK deploy → PR に URL コメント
+  deploy:
+    name: Deploy preview
+    needs: resolve
+    if: needs.resolve.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: TypeScript build
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Cache ffmpeg layer
+        id: ffmpeg-cache
+        uses: actions/cache@v4
+        with:
+          path: lambda-layers/ffmpeg-layer.zip
+          key: ffmpeg-layer-amd64-static-v4.4.2
+
+      - name: Build ffmpeg Lambda layer (dummy if cache miss)
+        if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p lambda-layers
+          if [ ! -f lambda-layers/ffmpeg-layer.zip ]; then
+            echo "dummy" | zip lambda-layers/ffmpeg-layer.zip - >/dev/null
+          fi
+
+      - name: Generate config.json (point to shared dev backend)
+        run: |
+          mkdir -p frontend/public
+          API_URL=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" --output text)
+          UPLOAD_URL=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='UploadApiUrl'].OutputValue" --output text)
+          CHAT_URL=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" --output text)
+          TEST_IMAGES_BUCKET=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='TestImagesBucketName'].OutputValue" --output text 2>/dev/null || echo "")
+          VERSION=$(node -p "require('./package.json').version")
+          BUILD_HASH=${GITHUB_SHA::7}
+          cat > frontend/public/config.json <<EOF
+          {"apiUrl":"${API_URL}","uploadApiUrl":"${UPLOAD_URL}","chatApiUrl":"${CHAT_URL}","cloudfrontUrl":"","version":"${VERSION}","buildHash":"${BUILD_HASH}-pr${{ needs.resolve.outputs.pr_number }}","environment":"pr-preview","buildTimestamp":"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)","region":"${{ env.AWS_REGION }}","s3BucketNames":{"testImages":"${TEST_IMAGES_BUCKET}"},"features":{"enableS3Upload":true,"enable3ImageComposition":true,"enableDebugMode":true,"enableAnalytics":true,"enableCaching":true,"enableErrorReporting":true}}
+          EOF
+
+      - name: Build frontend
+        run: cd frontend && npm ci && npm run build
+
+      - name: Deploy ${{ needs.resolve.outputs.stack_name }}
+        run: |
+          npx cdk deploy "${{ needs.resolve.outputs.stack_name }}" \
+            -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
+            -c previewBasicAuthUser="${{ secrets.PR_PREVIEW_BASIC_AUTH_USER }}" \
+            -c previewBasicAuthPass="${{ secrets.PR_PREVIEW_BASIC_AUTH_PASS }}" \
+            --require-approval never
+
+      - name: Get preview URL
+        id: url
+        run: |
+          URL=$(aws cloudformation describe-stacks \
+            --stack-name "${{ needs.resolve.outputs.stack_name }}" \
+            --query "Stacks[0].Outputs[?OutputKey=='FrontendUrl'].OutputValue" \
+            --output text)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.url.outputs.url }}';
+            const user = '${{ secrets.PR_PREVIEW_BASIC_AUTH_USER }}';
+            const pass = '${{ secrets.PR_PREVIEW_BASIC_AUTH_PASS }}';
+            const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
+            const body = [
+              '## PR Preview Deployed',
+              '',
+              `**URL**: ${url}`,
+              '',
+              '### Basic Auth credentials',
+              `- User: \`${user}\``,
+              `- Pass: \`${pass}\``,
+              '',
+              `Build: \`${sha}\` / Backend: \`${process.env.SHARED_DEV_API_STACK}\` を共有`,
+              '',
+              '> このプレビューは PR close で自動削除されます。`preview` ラベルを外すと即時 destroy できます。',
+              '> 7 日 idle のスタックは日次 cleanup で削除されます。',
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body && c.body.startsWith('## PR Preview Deployed')
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }
+        env:
+          SHARED_DEV_API_STACK: ${{ env.SHARED_DEV_API_STACK }}
+
+  destroy:
+    name: Destroy preview
+    needs: resolve
+    if: needs.resolve.outputs.should_destroy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: TypeScript build
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Check stack exists
+        id: check
+        run: |
+          if aws cloudformation describe-stacks --stack-name "${{ needs.resolve.outputs.stack_name }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Stack ${{ needs.resolve.outputs.stack_name }} not found — skip destroy"
+          fi
+
+      - name: Build dummy ffmpeg (for cdk synth)
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          mkdir -p lambda-layers
+          [ -f lambda-layers/ffmpeg-layer.zip ] || (echo "dummy" | zip lambda-layers/ffmpeg-layer.zip - >/dev/null)
+
+      - name: Destroy ${{ needs.resolve.outputs.stack_name }}
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          npx cdk destroy "${{ needs.resolve.outputs.stack_name }}" \
+            -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
+            -c previewBasicAuthUser="placeholder" \
+            -c previewBasicAuthPass="placeholder" \
+            --force
+
+      - name: Comment destroyed on PR
+        if: steps.check.outputs.exists == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '## PR Preview Destroyed',
+              '',
+              `\`${{ needs.resolve.outputs.stack_name }}\` を削除しました。`,
+              '',
+              '再度プレビューが必要な場合は `preview` ラベルを再度付与してください。',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -4,9 +4,9 @@
 # 仕様:
 #   - ラベル "preview" 付与時 / "preview" 付きの synchronize / reopen で deploy
 #   - PR close (merge 含む) で destroy
-#   - PR コメントに URL + Basic Auth credentials を自動投稿
+#   - PR コメントに URL を自動投稿
 #   - frontend のみ deploy (backend は共有 dev を参照)
-#   - Basic Auth credentials は repository secrets で管理
+#   - 認証は dev/main と同じく無し（URL は CloudFront ドメインの難読性に依存）
 #
 name: PR Preview
 
@@ -144,8 +144,6 @@ jobs:
         run: |
           npx cdk deploy "${{ needs.resolve.outputs.stack_name }}" \
             -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
-            -c previewBasicAuthUser="${{ secrets.PR_PREVIEW_BASIC_AUTH_USER }}" \
-            -c previewBasicAuthPass="${{ secrets.PR_PREVIEW_BASIC_AUTH_PASS }}" \
             --require-approval never
 
       - name: Get preview URL
@@ -162,20 +160,15 @@ jobs:
         with:
           script: |
             const url = '${{ steps.url.outputs.url }}';
-            const user = '${{ secrets.PR_PREVIEW_BASIC_AUTH_USER }}';
-            const pass = '${{ secrets.PR_PREVIEW_BASIC_AUTH_PASS }}';
             const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
             const body = [
               '## PR Preview Deployed',
               '',
               `**URL**: ${url}`,
               '',
-              '### Basic Auth credentials',
-              `- User: \`${user}\``,
-              `- Pass: \`${pass}\``,
-              '',
               `Build: \`${sha}\` / Backend: \`${process.env.SHARED_DEV_API_STACK}\` を共有`,
               '',
+              '> 認証なし（dev/main と同等）。URL は CloudFront ドメインの難読性に依存します。',
               '> このプレビューは PR close で自動削除されます。`preview` ラベルを外すと即時 destroy できます。',
               '> 7 日 idle のスタックは日次 cleanup で削除されます。',
             ].join('\n');
@@ -252,8 +245,6 @@ jobs:
         run: |
           npx cdk destroy "${{ needs.resolve.outputs.stack_name }}" \
             -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
-            -c previewBasicAuthUser="placeholder" \
-            -c previewBasicAuthPass="placeholder" \
             --force
 
       - name: Comment destroyed on PR

--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -25,7 +25,7 @@ inclusion: auto
 - **dev**: デバッグモード有効、ログレベルDEBUG
 - **staging**: デバッグモード無効、ログレベルINFO、本番同等設定
 - **production**: デバッグモード無効、ログレベルINFO、最適化済み
-- **PR preview**: `FrontendStack-Dev-Pr<num>` のみ独立、API URL は dev backend を共有。CloudFront Function による Basic Auth 付き。PR close または 7日 idle で自動 destroy（issue #87）
+- **PR preview**: `FrontendStack-Dev-Pr<num>` のみ独立、API URL は dev backend を共有。認証なし (dev/main と同等、URL 難読性に依存)。PR close または 7日 idle で自動 destroy（issue #87）
 
 ## サーバーレス原則
 

--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -13,6 +13,7 @@ inclusion: auto
 | dev | `-Dev` | feature/*, bugfix/* | 手動（ローカルから） |
 | staging | `-Staging` | dev | CI/CD自動 |
 | production | (なし) | main | CI/CD自動 |
+| **PR preview** | `-Dev-Pr<num>` | PR ブランチ（`preview` ラベル） | CI/CD自動（frontend のみ、共有 dev backend を参照） |
 
 ### 環境分離方式
 - CloudFormationスタック名にサフィックスを付与して同一アカウント内でリソースを分離
@@ -24,6 +25,7 @@ inclusion: auto
 - **dev**: デバッグモード有効、ログレベルDEBUG
 - **staging**: デバッグモード無効、ログレベルINFO、本番同等設定
 - **production**: デバッグモード無効、ログレベルINFO、最適化済み
+- **PR preview**: `FrontendStack-Dev-Pr<num>` のみ独立、API URL は dev backend を共有。CloudFront Function による Basic Auth 付き。PR close または 7日 idle で自動 destroy（issue #87）
 
 ## サーバーレス原則
 

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -74,7 +74,7 @@ npm run test:all-e2e
 
 - CI/CDパイプライン（`deploy.yml`）がデプロイ後に `e2e-test.yml` を自動呼び出し
 - 手動トリガー: Actions → E2E Test → Run workflow → 環境・テストスイート選択
-- **PR Preview**（`pr-preview.yml`）: `preview` ラベル付きの PR で frontend を ephemeral デプロイ → PR コメントに URL + Basic Auth credentials を投稿。PR close / ラベル解除で自動 destroy（issue #87）
+- **PR Preview**（`pr-preview.yml`）: `preview` ラベル付きの PR で frontend を ephemeral デプロイ → PR コメントに URL を投稿。認証なし (dev/main と同等)。PR close / ラベル解除で自動 destroy（issue #87）
 - **Stale Preview Cleanup**（`cleanup-stale-previews.yml`）: 日次 cron (UTC 18:00) で 7 日 idle の `FrontendStack-Dev-Pr*` を destroy
 
 ## テストコマンド

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -74,6 +74,8 @@ npm run test:all-e2e
 
 - CI/CDパイプライン（`deploy.yml`）がデプロイ後に `e2e-test.yml` を自動呼び出し
 - 手動トリガー: Actions → E2E Test → Run workflow → 環境・テストスイート選択
+- **PR Preview**（`pr-preview.yml`）: `preview` ラベル付きの PR で frontend を ephemeral デプロイ → PR コメントに URL + Basic Auth credentials を投稿。PR close / ラベル解除で自動 destroy（issue #87）
+- **Stale Preview Cleanup**（`cleanup-stale-previews.yml`）: 日次 cron (UTC 18:00) で 7 日 idle の `FrontendStack-Dev-Pr*` を destroy
 
 ## テストコマンド
 

--- a/.kiro/steering/workflow.md
+++ b/.kiro/steering/workflow.md
@@ -112,15 +112,17 @@ dev環境デプロイ後のe2eテスト手順は [testing.md](testing.md) の「
 PR open / push / label "preview" 追加
   ↓ .github/workflows/pr-preview.yml
   ├ build frontend (config.json は共有 dev backend を指す)
-  ├ cdk deploy FrontendStack-Dev-Pr<num>（CloudFront + S3、Basic Auth 付き）
-  └ PR コメントに URL + Basic Auth credentials を自動投稿
+  ├ cdk deploy FrontendStack-Dev-Pr<num>（CloudFront + S3）
+  └ PR コメントに URL を自動投稿
 ```
 
-レビュアーは PR コメントの URL と credentials で実機にアクセスして UI を確認できる。`preview` ラベルを外す or PR を close すると自動 destroy。さらに 7 日 idle のスタックは日次 cleanup ワークフローで自動削除される。
+レビュアーは PR コメントの URL から実機にアクセスして UI を確認できる。`preview` ラベルを外す or PR を close すると自動 destroy。さらに 7 日 idle のスタックは日次 cleanup ワークフローで自動削除される。
+
+**認証**: dev/main と同様に無し。CloudFront ドメインの難読性に依存（限定共有用途）。
 
 **前提**:
 - `ImageProcessorApiStack-Dev`（共有 dev backend）が存在すること
-- repo secrets: `AWS_DEPLOY_ROLE_ARN`, `PR_PREVIEW_BASIC_AUTH_USER`, `PR_PREVIEW_BASIC_AUTH_PASS`
+- repo secrets: `AWS_DEPLOY_ROLE_ARN`
 
 **スコープ**:
 - frontend stack のみ deploy（backend は共有 dev を参照）

--- a/.kiro/steering/workflow.md
+++ b/.kiro/steering/workflow.md
@@ -104,6 +104,28 @@ dev環境デプロイ後のe2eテスト手順は [testing.md](testing.md) の「
 - レビュー → フィードバック対応
 - **devブランチへのマージは指示があるまで行わない**
 
+#### PR Preview（UI 変更を含む PR の実機レビュー） — issue #87
+
+`frontend/` 配下の変更を含む PR で UI 動作確認が必要な場合、PR に `preview` ラベルを付与すると ephemeral preview 環境が自動で立ち上がる:
+
+```
+PR open / push / label "preview" 追加
+  ↓ .github/workflows/pr-preview.yml
+  ├ build frontend (config.json は共有 dev backend を指す)
+  ├ cdk deploy FrontendStack-Dev-Pr<num>（CloudFront + S3、Basic Auth 付き）
+  └ PR コメントに URL + Basic Auth credentials を自動投稿
+```
+
+レビュアーは PR コメントの URL と credentials で実機にアクセスして UI を確認できる。`preview` ラベルを外す or PR を close すると自動 destroy。さらに 7 日 idle のスタックは日次 cleanup ワークフローで自動削除される。
+
+**前提**:
+- `ImageProcessorApiStack-Dev`（共有 dev backend）が存在すること
+- repo secrets: `AWS_DEPLOY_ROLE_ARN`, `PR_PREVIEW_BASIC_AUTH_USER`, `PR_PREVIEW_BASIC_AUTH_PASS`
+
+**スコープ**:
+- frontend stack のみ deploy（backend は共有 dev を参照）
+- backend 変更を含む PR は staging まで進めて確認する
+
 ### ステップ8: devへマージ → staging環境で統合テスト
 - 指示を受けてからdevにマージ
 - CI/CDがstaging環境に自動デプロイ

--- a/bin/image-processor-api.ts
+++ b/bin/image-processor-api.ts
@@ -17,15 +17,10 @@ const env = {
 // PR preview モード（issue #87）:
 //   -c previewPr=<num> を渡すと、共有 dev backend を参照する単独 frontend stack
 //   `FrontendStack-Dev-Pr<num>` のみを作成する。バックエンドは作成しない。
-//   credentials は -c previewBasicAuthUser=<u> -c previewBasicAuthPass=<p> で渡す。
+//   認証は dev/main と同じく無し（CloudFront URL の難読性に依存）。
 const previewPr = app.node.tryGetContext('previewPr') as string | undefined;
 
 if (previewPr) {
-  const previewUser = app.node.tryGetContext('previewBasicAuthUser') as string | undefined;
-  const previewPass = app.node.tryGetContext('previewBasicAuthPass') as string | undefined;
-  if (!previewUser || !previewPass) {
-    throw new Error('previewBasicAuthUser/previewBasicAuthPass context が必須です');
-  }
   if (!/^\d+$/.test(previewPr)) {
     throw new Error(`previewPr は数値のみ。received: ${previewPr}`);
   }
@@ -58,7 +53,6 @@ if (previewPr) {
     },
     envConfig: previewEnvConfig,
     importEnvConfig: sharedDevConfig,
-    basicAuth: { user: previewUser, pass: previewPass },
   });
 } else {
   // 通常モード: backend + frontend を envConfig.suffix で作成

--- a/bin/image-processor-api.ts
+++ b/bin/image-processor-api.ts
@@ -4,12 +4,9 @@ import * as cdk from 'aws-cdk-lib';
 import { ImageProcessorApiStack } from '../lib/image-processor-api-stack';
 import { ImageCompositeViewerStack } from '../lib/image-composite-viewer-stack';
 import { FrontendStack } from '../lib/frontend-stack';
-import { resolveEnvironment } from '../lib/environment';
+import { resolveEnvironment, EnvironmentConfig } from '../lib/environment';
 
 const app = new cdk.App();
-
-// 環境設定を解決（-c environment=dev|staging|production）
-const envConfig = resolveEnvironment(app);
 
 // AWS環境設定（defaultプロファイルを使用）
 const env = {
@@ -17,39 +14,83 @@ const env = {
   region: process.env.CDK_DEFAULT_REGION,
 };
 
-// タグの設定
-const tags = {
-  Project: 'ImageProcessorAPI',
-  Version: 'v2',
-  Environment: envConfig.name,
-};
+// PR preview モード（issue #87）:
+//   -c previewPr=<num> を渡すと、共有 dev backend を参照する単独 frontend stack
+//   `FrontendStack-Dev-Pr<num>` のみを作成する。バックエンドは作成しない。
+//   credentials は -c previewBasicAuthUser=<u> -c previewBasicAuthPass=<p> で渡す。
+const previewPr = app.node.tryGetContext('previewPr') as string | undefined;
 
-// バックエンドスタックをデプロイ
-const apiStack = new ImageProcessorApiStack(app, `ImageProcessorApiStack${envConfig.suffix}`, {
-  description: 'Advanced Image Composition REST API with Alpha Channel Support',
-  env,
-  tags,
-  envConfig,
-});
+if (previewPr) {
+  const previewUser = app.node.tryGetContext('previewBasicAuthUser') as string | undefined;
+  const previewPass = app.node.tryGetContext('previewBasicAuthPass') as string | undefined;
+  if (!previewUser || !previewPass) {
+    throw new Error('previewBasicAuthUser/previewBasicAuthPass context が必須です');
+  }
+  if (!/^\d+$/.test(previewPr)) {
+    throw new Error(`previewPr は数値のみ。received: ${previewPr}`);
+  }
 
-// フロントエンドスタックをデプロイ（旧）
-const viewerStack = new ImageCompositeViewerStack(app, `ImageCompositeViewerStack${envConfig.suffix}`, {
-  description: 'Frontend Viewer for Image Composition REST API',
-  env,
-  tags,
-  apiEndpoint: apiStack.apiEndpoint,
-  uploadApiEndpoint: apiStack.uploadApiEndpoint,
-  envConfig,
-});
+  // PR preview stack 用の envConfig (-Dev-Pr<num> サフィックス)
+  const previewSuffix = `-Dev-Pr${previewPr}`;
+  const previewResourceSuffix = `-dev-pr${previewPr}`;
+  const previewEnvConfig: EnvironmentConfig = {
+    name: 'dev',
+    suffix: previewSuffix,
+    resourceSuffix: previewResourceSuffix,
+    isProduction: false,
+  };
+  // 参照先（共有 dev backend）の envConfig
+  const sharedDevConfig: EnvironmentConfig = {
+    name: 'dev',
+    suffix: '-Dev',
+    resourceSuffix: '-dev',
+    isProduction: false,
+  };
 
-// スタック間の依存関係を設定（フロントエンドはバックエンドに依存）
-viewerStack.addDependency(apiStack);
+  new FrontendStack(app, `FrontendStack${previewSuffix}`, {
+    description: `PR #${previewPr} Preview Frontend (shared dev backend)`,
+    env,
+    tags: {
+      Project: 'ImageProcessorAPI',
+      Version: 'v2',
+      Environment: 'dev',
+      PreviewPR: previewPr,
+    },
+    envConfig: previewEnvConfig,
+    importEnvConfig: sharedDevConfig,
+    basicAuth: { user: previewUser, pass: previewPass },
+  });
+} else {
+  // 通常モード: backend + frontend を envConfig.suffix で作成
+  const envConfig = resolveEnvironment(app);
+  const tags = {
+    Project: 'ImageProcessorAPI',
+    Version: 'v2',
+    Environment: envConfig.name,
+  };
 
-// 新フロントエンドスタック（独立デプロイ対応）
-const frontendStack = new FrontendStack(app, `FrontendStack${envConfig.suffix}`, {
-  description: 'Frontend for Image Compositor (independent deploy)',
-  env,
-  tags,
-  envConfig,
-});
-frontendStack.addDependency(apiStack);
+  const apiStack = new ImageProcessorApiStack(app, `ImageProcessorApiStack${envConfig.suffix}`, {
+    description: 'Advanced Image Composition REST API with Alpha Channel Support',
+    env,
+    tags,
+    envConfig,
+  });
+
+  const viewerStack = new ImageCompositeViewerStack(app, `ImageCompositeViewerStack${envConfig.suffix}`, {
+    description: 'Frontend Viewer for Image Composition REST API',
+    env,
+    tags,
+    apiEndpoint: apiStack.apiEndpoint,
+    uploadApiEndpoint: apiStack.uploadApiEndpoint,
+    envConfig,
+  });
+  viewerStack.addDependency(apiStack);
+
+  const frontendStack = new FrontendStack(app, `FrontendStack${envConfig.suffix}`, {
+    description: 'Frontend for Image Compositor (independent deploy)',
+    env,
+    tags,
+    envConfig,
+  });
+  frontendStack.addDependency(apiStack);
+}

--- a/lib/frontend-stack.ts
+++ b/lib/frontend-stack.ts
@@ -21,12 +21,6 @@ export interface FrontendStackProps extends cdk.StackProps {
    * PR preview では `-Dev` (共有バックエンド) を指す config を渡す想定。
    */
   importEnvConfig?: EnvironmentConfig;
-  /**
-   * Basic 認証を CloudFront Function で適用する場合に指定。
-   * PR preview 等の限定公開用途を想定し、credentials はインラインで CF Function に
-   * 埋め込まれる（CF Function は size 10KB 上限の sync JS）。
-   */
-  basicAuth?: { user: string; pass: string };
 }
 
 export class FrontendStack extends cdk.Stack {
@@ -68,36 +62,6 @@ export class FrontendStack extends cdk.Stack {
     const resourcesOAI = cloudfront.OriginAccessIdentity.fromOriginAccessIdentityId(
       this, 'ResourcesOAI', resourcesOAIId
     );
-
-    // --- Basic Auth CloudFront Function (PR preview 用) ---
-    // CF Function は viewer-request 時に同期実行される軽量 JS。Basic Auth ヘッダ未一致時は
-    // 401 を即返す。credentials はインライン埋め込み（PR preview の限定公開用途のため
-    // 高度な秘匿化は不要）。本番 distribution には付与しない。
-    let viewerRequestFn: cloudfront.Function | undefined;
-    if (props.basicAuth) {
-      const credsB64 = Buffer.from(`${props.basicAuth.user}:${props.basicAuth.pass}`).toString('base64');
-      const fnCode = `function handler(event) {
-  var request = event.request;
-  var headers = request.headers;
-  var expected = 'Basic ${credsB64}';
-  if (!headers.authorization || headers.authorization.value !== expected) {
-    return {
-      statusCode: 401,
-      statusDescription: 'Unauthorized',
-      headers: { 'www-authenticate': { value: 'Basic realm="PR Preview"' } },
-    };
-  }
-  return request;
-}`;
-      viewerRequestFn = new cloudfront.Function(this, 'PreviewBasicAuthFunction', {
-        functionName: envName('frontend-preview-basicauth', envConfig),
-        code: cloudfront.FunctionCode.fromInline(fnCode),
-      });
-    }
-    const fnAssociations = viewerRequestFn ? [{
-      function: viewerRequestFn,
-      eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-    }] : undefined;
 
     // --- ResponseHeadersPolicy ---
     // index.html / config用: no-cache
@@ -143,7 +107,6 @@ export class FrontendStack extends cdk.Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: shortCachePolicy,
         responseHeadersPolicy: noCachePolicy,
-        functionAssociations: fnAssociations,
       },
       additionalBehaviors: {
         // アセット（JS/CSS）→ 60秒キャッシュ
@@ -154,8 +117,7 @@ export class FrontendStack extends cdk.Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: shortCachePolicy,
           responseHeadersPolicy: noCachePolicy,
-          functionAssociations: fnAssociations,
-        },
+          },
         // 合成画像（リソースバケット）
         'generated-images/*': {
           origin: new origins.S3Origin(resourcesBucket, { originAccessIdentity: resourcesOAI }),
@@ -164,8 +126,7 @@ export class FrontendStack extends cdk.Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: shortCachePolicy,
           responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
-          functionAssociations: fnAssociations,
-        },
+          },
         // 動画（リソースバケット）
         'generated-videos/*': {
           origin: new origins.S3Origin(resourcesBucket, { originAccessIdentity: resourcesOAI }),
@@ -182,8 +143,7 @@ export class FrontendStack extends cdk.Stack {
             queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
           }),
           responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
-          functionAssociations: fnAssociations,
-        },
+          },
       },
       // SPA: 404/403 → index.html
       errorResponses: [

--- a/lib/frontend-stack.ts
+++ b/lib/frontend-stack.ts
@@ -13,13 +13,30 @@ import { EnvironmentConfig, envName, envExport } from './environment';
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json'), 'utf-8'));
 const VERSION = packageJson.version;
 
+export interface FrontendStackProps extends cdk.StackProps {
+  envConfig: EnvironmentConfig;
+  /**
+   * PR preview モード用: ImageProcessorApiStack の参照に使う EnvironmentConfig。
+   * 省略時は envConfig を使用（通常 dev/staging/production）。
+   * PR preview では `-Dev` (共有バックエンド) を指す config を渡す想定。
+   */
+  importEnvConfig?: EnvironmentConfig;
+  /**
+   * Basic 認証を CloudFront Function で適用する場合に指定。
+   * PR preview 等の限定公開用途を想定し、credentials はインラインで CF Function に
+   * 埋め込まれる（CF Function は size 10KB 上限の sync JS）。
+   */
+  basicAuth?: { user: string; pass: string };
+}
+
 export class FrontendStack extends cdk.Stack {
   public readonly distribution: cloudfront.Distribution;
   public readonly frontendBucket: s3.Bucket;
 
-  constructor(scope: Construct, id: string, props: cdk.StackProps & { envConfig: EnvironmentConfig }) {
+  constructor(scope: Construct, id: string, props: FrontendStackProps) {
     super(scope, id, props);
     const envConfig = props.envConfig;
+    const importConfig = props.importEnvConfig ?? envConfig;
 
     // --- S3バケット ---
     this.frontendBucket = new s3.Bucket(this, 'FrontendBucket', {
@@ -28,8 +45,9 @@ export class FrontendStack extends cdk.Stack {
     });
 
     // --- クロススタック参照 ---
-    const resourcesBucketName = cdk.Fn.importValue(envExport('ImageProcessorResourcesBucketName', envConfig));
-    const resourcesBucketArn = cdk.Fn.importValue(envExport('ImageProcessorResourcesBucketArn', envConfig));
+    // PR preview モード時は共有 dev backend を参照するため importConfig を使う
+    const resourcesBucketName = cdk.Fn.importValue(envExport('ImageProcessorResourcesBucketName', importConfig));
+    const resourcesBucketArn = cdk.Fn.importValue(envExport('ImageProcessorResourcesBucketArn', importConfig));
 
     // リソースバケットの参照（generated-images/videos配信用）
     const resourcesBucket = s3.Bucket.fromBucketAttributes(this, 'ResourcesBucket', {
@@ -46,10 +64,40 @@ export class FrontendStack extends cdk.Stack {
     }));
 
     // リソースバケット用OAI: ApiStack側で作成・権限付与済み、IDをimportして使用
-    const resourcesOAIId = cdk.Fn.importValue(envExport('FrontendResourcesOAIId', envConfig));
+    const resourcesOAIId = cdk.Fn.importValue(envExport('FrontendResourcesOAIId', importConfig));
     const resourcesOAI = cloudfront.OriginAccessIdentity.fromOriginAccessIdentityId(
       this, 'ResourcesOAI', resourcesOAIId
     );
+
+    // --- Basic Auth CloudFront Function (PR preview 用) ---
+    // CF Function は viewer-request 時に同期実行される軽量 JS。Basic Auth ヘッダ未一致時は
+    // 401 を即返す。credentials はインライン埋め込み（PR preview の限定公開用途のため
+    // 高度な秘匿化は不要）。本番 distribution には付与しない。
+    let viewerRequestFn: cloudfront.Function | undefined;
+    if (props.basicAuth) {
+      const credsB64 = Buffer.from(`${props.basicAuth.user}:${props.basicAuth.pass}`).toString('base64');
+      const fnCode = `function handler(event) {
+  var request = event.request;
+  var headers = request.headers;
+  var expected = 'Basic ${credsB64}';
+  if (!headers.authorization || headers.authorization.value !== expected) {
+    return {
+      statusCode: 401,
+      statusDescription: 'Unauthorized',
+      headers: { 'www-authenticate': { value: 'Basic realm="PR Preview"' } },
+    };
+  }
+  return request;
+}`;
+      viewerRequestFn = new cloudfront.Function(this, 'PreviewBasicAuthFunction', {
+        functionName: envName('frontend-preview-basicauth', envConfig),
+        code: cloudfront.FunctionCode.fromInline(fnCode),
+      });
+    }
+    const fnAssociations = viewerRequestFn ? [{
+      function: viewerRequestFn,
+      eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+    }] : undefined;
 
     // --- ResponseHeadersPolicy ---
     // index.html / config用: no-cache
@@ -95,6 +143,7 @@ export class FrontendStack extends cdk.Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: shortCachePolicy,
         responseHeadersPolicy: noCachePolicy,
+        functionAssociations: fnAssociations,
       },
       additionalBehaviors: {
         // アセット（JS/CSS）→ 60秒キャッシュ
@@ -105,6 +154,7 @@ export class FrontendStack extends cdk.Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: shortCachePolicy,
           responseHeadersPolicy: noCachePolicy,
+          functionAssociations: fnAssociations,
         },
         // 合成画像（リソースバケット）
         'generated-images/*': {
@@ -114,6 +164,7 @@ export class FrontendStack extends cdk.Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: shortCachePolicy,
           responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
+          functionAssociations: fnAssociations,
         },
         // 動画（リソースバケット）
         'generated-videos/*': {
@@ -131,6 +182,7 @@ export class FrontendStack extends cdk.Stack {
             queryStringBehavior: cloudfront.CacheQueryStringBehavior.none(),
           }),
           responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
+          functionAssociations: fnAssociations,
         },
       },
       // SPA: 404/403 → index.html


### PR DESCRIPTION
Closes #87 (MVP)

## Summary

PR レビュアーが UI 変更を実機で確認できるよう、`preview` ラベル付きの PR で短命 CloudFront + S3 frontend stack を自動デプロイする仕組みを追加。

## 仕組み

```
PR open / push / label "preview"
  ↓ .github/workflows/pr-preview.yml
  ├ build frontend (config.json は共有 dev backend を指す)
  ├ cdk deploy FrontendStack-Dev-Pr<num>（CloudFront + S3、Basic Auth 付き）
  └ PR コメントに URL + Basic Auth credentials を自動投稿（既存コメントは更新）

PR close / preview ラベル解除
  ↓
  └ cdk destroy FrontendStack-Dev-Pr<num>

cron daily UTC 18:00
  ↓
  └ 7 日 idle の FrontendStack-Dev-Pr* を一括 destroy
```

backend は共有 `ImageProcessorApiStack-Dev` を参照するため、preview ごとに重複 backend は作成されない。

## 主な変更

### `lib/frontend-stack.ts`
- `FrontendStackProps` に追加:
  - `importEnvConfig?: EnvironmentConfig` — クロススタック参照先（preview 時は dev 共有 backend）
  - `basicAuth?: { user, pass }` — CloudFront Function 注入用
- Basic Auth Function を生成 → 全 4 behaviors (default + assets/* + generated-images/* + generated-videos/*) に attach
- credentials は base64 化してインライン埋め込み（CF Function は sync JS、サイズ 10KB 上限）

### `bin/image-processor-api.ts`
- `-c previewPr=<num>` 指定時は **frontend stack のみ作成**、共有 dev backend を import
- 通常モード（dev/staging/production）のコードパスは無変更

### Workflows
- `.github/workflows/pr-preview.yml`: pull_request の opened/labeled/synchronize/closed/unlabeled に応じて deploy / destroy / PR コメント
- `.github/workflows/cleanup-stale-previews.yml`: 日次 cron + workflow_dispatch（dry-run 対応）

### Docs
- `.kiro/steering/architecture.md`: 環境表に `PR preview / -Dev-Pr<num>` 追加
- `.kiro/steering/testing.md`: GitHub Actions 節に PR preview / Cleanup ワークフロー追記
- `.kiro/steering/workflow.md`: ステップ7 (PR 作成) に PR Preview 利用手順追加

## 必要な repository secrets

| Secret | 既存/新規 | 用途 |
|---|---|---|
| `AWS_DEPLOY_ROLE_ARN` | 既存 | CDK deploy/destroy |
| `PR_PREVIEW_BASIC_AUTH_USER` | **新規** | CF Function に埋め込む user |
| `PR_PREVIEW_BASIC_AUTH_PASS` | **新規** | CF Function に埋め込む pass |

マージ前に2つの新規 secret を repository settings に登録する必要があります。

## Test plan

- [x] ローカル CDK synth: `FrontendStack-Dev-Pr123` のみが list / synth、Basic Auth CF Function が 4 behaviors すべてに attach されることを確認
- [x] CI Frontend Build & Lint
- [x] CI Lambda Unit Tests
- [x] CI Frontend Unit Tests
- [ ] CI CDK Build & Synth pass（ローカル ARM Pi では vite Illegal instruction で確認不可、x86 CI で検証）
- [ ] マージ後、本 PR 自体に `preview` ラベル付与で end-to-end 動作確認

## スコープ外（将来検討）

- backend を含む PR preview（現状 frontend のみ）
- Visual Regression (issue 中の手法 B、後続 PR で incremental に追加可)
- 認証を Basic Auth から GitHub OAuth 等に強化

🤖 Generated with [Claude Code](https://claude.com/claude-code)