### PR TITLE
feat(ci): PR Preview を backend + frontend per-PR 化（full E2E 対応）

### DIFF
--- a/.github/workflows/cleanup-stale-previews.yml
+++ b/.github/workflows/cleanup-stale-previews.yml
@@ -1,9 +1,10 @@
-# Stale PR Preview Cleanup - 7 日 idle の FrontendStack-Dev-Pr* を destroy
+# Stale PR Preview Cleanup - 7 日 idle の preview スタックを destroy
 # issue #87: PR preview の孤児スタック防止
 #
 # 仕様:
 #   - 日次 cron (UTC 18:00 = JST 03:00) で実行
-#   - LastUpdatedTime > 7 日前の FrontendStack-Dev-Pr<num> を destroy
+#   - 対象: `FrontendStack-Dev-Pr<num>` と `ImageProcessorApiStack-Dev-Pr<num>`
+#   - LastUpdatedTime > 7 日前の PR 番号セットを stale 判定し、frontend → backend の順で destroy
 #   - 対応する PR が open + preview ラベル付きでも 7 日経てば destroy（label 再付与で再 deploy 可能）
 #   - 手動 workflow_dispatch にも対応
 #
@@ -72,40 +73,65 @@ jobs:
           echo "Dry run: $DRY_RUN"
           echo ""
 
-          # FrontendStack-Dev-Pr* 一覧を取得
-          STACKS=$(aws cloudformation list-stacks \
+          # frontend / backend preview stack 一覧を取得し、PR 番号でまとめる
+          FRONT_STACKS=$(aws cloudformation list-stacks \
             --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
             --query "StackSummaries[?starts_with(StackName, 'FrontendStack-Dev-Pr')].StackName" \
             --output text || echo "")
+          API_STACKS=$(aws cloudformation list-stacks \
+            --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
+            --query "StackSummaries[?starts_with(StackName, 'ImageProcessorApiStack-Dev-Pr')].StackName" \
+            --output text || echo "")
 
-          if [ -z "$STACKS" ]; then
+          if [ -z "$FRONT_STACKS" ] && [ -z "$API_STACKS" ]; then
             echo "No PR preview stacks found."
             exit 0
           fi
 
-          DESTROYED=0
-          KEPT=0
-          for STACK in $STACKS; do
-            LAST_UPDATED=$(aws cloudformation describe-stacks --stack-name "$STACK" \
-              --query "Stacks[0].LastUpdatedTime || Stacks[0].CreationTime" --output text)
-            LAST_EPOCH=$(date -u -d "$LAST_UPDATED" +%s)
-            AGE_DAYS=$(( ( $(date -u +%s) - LAST_EPOCH ) / 86400 ))
+          # 全 preview stack の PR 番号セットを抽出（frontend と backend をマージ）
+          PR_NUMS=$(
+            { echo "$FRONT_STACKS" | tr '\t' '\n' | sed -nE 's/^FrontendStack-Dev-Pr([0-9]+).*$/\1/p';
+              echo "$API_STACKS"   | tr '\t' '\n' | sed -nE 's/^ImageProcessorApiStack-Dev-Pr([0-9]+).*$/\1/p'; \
+            } | sort -u | grep -v '^$' || true
+          )
 
-            if [ $LAST_EPOCH -lt $THRESHOLD_EPOCH ]; then
-              echo "  [STALE  ${AGE_DAYS}d] $STACK"
+          DESTROYED_GROUPS=0
+          KEPT_GROUPS=0
+          for PR_NUM in $PR_NUMS; do
+            FRONT="FrontendStack-Dev-Pr${PR_NUM}"
+            API="ImageProcessorApiStack-Dev-Pr${PR_NUM}"
+
+            # 各 stack の LastUpdated を取得（存在しない場合は 0）
+            LATEST=0
+            for STACK in "$FRONT" "$API"; do
+              LU=$(aws cloudformation describe-stacks --stack-name "$STACK" \
+                --query "Stacks[0].LastUpdatedTime || Stacks[0].CreationTime" --output text 2>/dev/null || echo "")
+              if [ -n "$LU" ]; then
+                EPOCH=$(date -u -d "$LU" +%s)
+                if [ "$EPOCH" -gt "$LATEST" ]; then
+                  LATEST=$EPOCH
+                fi
+              fi
+            done
+            AGE_DAYS=$(( ( $(date -u +%s) - LATEST ) / 86400 ))
+
+            if [ "$LATEST" -lt "$THRESHOLD_EPOCH" ]; then
+              echo "  [STALE  ${AGE_DAYS}d] PR #${PR_NUM} (frontend + backend)"
               if [ "$DRY_RUN" != "true" ]; then
-                # PR 番号を stack 名から抽出
-                PR_NUM=$(echo "$STACK" | sed -E 's/^FrontendStack-Dev-Pr([0-9]+).*$/\1/')
-                npx cdk destroy "$STACK" \
-                  -c previewPr="$PR_NUM" \
-                  --force
-                DESTROYED=$((DESTROYED + 1))
+                # frontend → backend の順で destroy（依存方向）
+                if aws cloudformation describe-stacks --stack-name "$FRONT" >/dev/null 2>&1; then
+                  npx cdk destroy "$FRONT" -c previewPr="$PR_NUM" --force
+                fi
+                if aws cloudformation describe-stacks --stack-name "$API" >/dev/null 2>&1; then
+                  npx cdk destroy "$API" -c previewPr="$PR_NUM" --force
+                fi
+                DESTROYED_GROUPS=$((DESTROYED_GROUPS + 1))
               fi
             else
-              echo "  [keep   ${AGE_DAYS}d] $STACK"
-              KEPT=$((KEPT + 1))
+              echo "  [keep   ${AGE_DAYS}d] PR #${PR_NUM}"
+              KEPT_GROUPS=$((KEPT_GROUPS + 1))
             fi
           done
 
           echo ""
-          echo "Summary: destroyed=$DESTROYED, kept=$KEPT"
+          echo "Summary: destroyed_pr_groups=$DESTROYED_GROUPS, kept_pr_groups=$KEPT_GROUPS"

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,11 +1,12 @@
-# PR Preview - 短命 frontend stack を CloudFront + S3 でデプロイ
-# issue #87: PR レビュアーが UI を実機で確認するための ephemeral preview
+# PR Preview - 短命 backend + frontend stack をデプロイ
+# issue #87: PR レビュアーが UI + API を実機で確認するための ephemeral preview
 #
 # 仕様:
 #   - ラベル "preview" 付与時 / "preview" 付きの synchronize / reopen で deploy
-#   - PR close (merge 含む) で destroy
+#   - backend (`ImageProcessorApiStack-Dev-Pr<num>`) + frontend (`FrontendStack-Dev-Pr<num>`)
+#     両方を per-PR で作成。frontend は自身の per-PR backend を参照する
+#   - PR close (merge 含む) で両スタック destroy（frontend → backend の順）
 #   - PR コメントに URL を自動投稿
-#   - frontend のみ deploy (backend は共有 dev を参照)
 #   - 認証は dev/main と同じく無し（URL は CloudFront ドメインの難読性に依存）
 #
 name: PR Preview
@@ -25,10 +26,9 @@ concurrency:
 
 env:
   NODE_VERSION: "22"
+  PYTHON_VERSION: "3.12"
   AWS_REGION: ap-northeast-1
   PREVIEW_LABEL: preview
-  SHARED_DEV_API_STACK: ImageProcessorApiStack-Dev
-  SHARED_DEV_FRONTEND_STACK: FrontendStack-Dev
 
 jobs:
   # 共通: ラベル状態を解決
@@ -37,7 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.r.outputs.pr_number }}
-      stack_name: ${{ steps.r.outputs.stack_name }}
+      api_stack: ${{ steps.r.outputs.api_stack }}
+      frontend_stack: ${{ steps.r.outputs.frontend_stack }}
       should_deploy: ${{ steps.r.outputs.should_deploy }}
       should_destroy: ${{ steps.r.outputs.should_destroy }}
     steps:
@@ -48,9 +49,11 @@ jobs:
           # PR の現在ラベル一覧 (closed 時もそのまま参照可)
           HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'preview') }}
         run: |
-          STACK="FrontendStack-Dev-Pr${PR_NUM}"
+          API_STACK="ImageProcessorApiStack-Dev-Pr${PR_NUM}"
+          FRONTEND_STACK="FrontendStack-Dev-Pr${PR_NUM}"
           echo "pr_number=${PR_NUM}" >> "$GITHUB_OUTPUT"
-          echo "stack_name=${STACK}" >> "$GITHUB_OUTPUT"
+          echo "api_stack=${API_STACK}" >> "$GITHUB_OUTPUT"
+          echo "frontend_stack=${FRONTEND_STACK}" >> "$GITHUB_OUTPUT"
 
           # deploy 条件: preview ラベルが付いた状態で {opened, labeled, synchronize, reopened}
           if [ "$ACTION" = "closed" ]; then
@@ -74,15 +77,15 @@ jobs:
             echo "should_destroy=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "Stack: $STACK / Action: $ACTION / has-label: $HAS_LABEL"
+          echo "Stacks: $API_STACK + $FRONTEND_STACK / Action: $ACTION / has-label: $HAS_LABEL"
 
-  # frontend を build → CDK deploy → PR に URL コメント
+  # backend + frontend を build → CDK deploy → PR に URL コメント
   deploy:
     name: Deploy preview
     needs: resolve
     if: needs.resolve.outputs.should_deploy == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -92,6 +95,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install root dependencies
         run: npm ci
@@ -112,24 +119,36 @@ jobs:
           path: lambda-layers/ffmpeg-layer.zip
           key: ffmpeg-layer-amd64-static-v4.4.2
 
-      - name: Build ffmpeg Lambda layer (dummy if cache miss)
+      - name: Build ffmpeg Lambda layer
         if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p lambda-layers
-          if [ ! -f lambda-layers/ffmpeg-layer.zip ]; then
-            echo "dummy" | zip lambda-layers/ffmpeg-layer.zip - >/dev/null
-          fi
+        run: bash scripts/create-ffmpeg-layer.sh
 
-      - name: Generate config.json (point to shared dev backend)
+      - name: Copy composite-default.json for Lambda bundling
+        # frontend/public/ がソース、lambda/python/composite_defaults.json は git 管理外
+        run: |
+          cp frontend/public/composite-default.json lambda/python/composite_defaults.json
+          echo "✅ composite_defaults.json copied for Lambda bundling"
+
+      - name: Deploy backend ${{ needs.resolve.outputs.api_stack }}
+        run: |
+          npx cdk deploy "${{ needs.resolve.outputs.api_stack }}" \
+            -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
+            --require-approval never
+        env:
+          AGENTMODEL: ${{ vars.AGENTMODEL || 'us.amazon.nova-2-lite-v1:0' }}
+          ENVIRONMENT: dev
+
+      - name: Generate config.json (point to per-PR backend)
         run: |
           mkdir -p frontend/public
-          API_URL=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+          API_STACK="${{ needs.resolve.outputs.api_stack }}"
+          API_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" --output text)
-          UPLOAD_URL=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+          UPLOAD_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='UploadApiUrl'].OutputValue" --output text)
-          CHAT_URL=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+          CHAT_URL=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='ChatApiUrl'].OutputValue" --output text)
-          TEST_IMAGES_BUCKET=$(aws cloudformation describe-stacks --stack-name "$SHARED_DEV_API_STACK" \
+          TEST_IMAGES_BUCKET=$(aws cloudformation describe-stacks --stack-name "$API_STACK" \
             --query "Stacks[0].Outputs[?OutputKey=='TestImagesBucketName'].OutputValue" --output text 2>/dev/null || echo "")
           VERSION=$(node -p "require('./package.json').version")
           BUILD_HASH=${GITHUB_SHA::7}
@@ -140,33 +159,60 @@ jobs:
       - name: Build frontend
         run: cd frontend && npm ci && npm run build
 
-      - name: Deploy ${{ needs.resolve.outputs.stack_name }}
+      - name: Deploy frontend ${{ needs.resolve.outputs.frontend_stack }}
         run: |
-          npx cdk deploy "${{ needs.resolve.outputs.stack_name }}" \
+          npx cdk deploy "${{ needs.resolve.outputs.frontend_stack }}" \
             -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
             --require-approval never
+
+      - name: Update Lambda CLOUDFRONT_DOMAIN
+        run: |
+          API_STACK="${{ needs.resolve.outputs.api_stack }}"
+          FRONT_STACK="${{ needs.resolve.outputs.frontend_stack }}"
+          CF_DOMAIN=$(aws cloudformation describe-stacks --stack-name "$FRONT_STACK" \
+            --query "Stacks[0].Outputs[?OutputKey=='DistributionDomain'].OutputValue" --output text)
+          if [ -n "$CF_DOMAIN" ]; then
+            # Lambda 関数名は 64 字制限で切り詰められるため CFN スタックリソースから物理 ID を取得
+            for FUNC_NAME in $(aws cloudformation list-stack-resources --stack-name "$API_STACK" \
+              --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function' && (contains(LogicalResourceId, 'ImageProcessor') || contains(LogicalResourceId, 'AgentFunction'))].PhysicalResourceId" \
+              --output text); do
+              CURRENT_ENV=$(aws lambda get-function-configuration --function-name "$FUNC_NAME" --query "Environment.Variables" --output json)
+              UPDATED_ENV=$(echo "$CURRENT_ENV" | python3 -c "import sys,json; d=json.load(sys.stdin); d['CLOUDFRONT_DOMAIN']='${CF_DOMAIN}'; print(json.dumps({'Variables':d}))")
+              aws lambda update-function-configuration --function-name "$FUNC_NAME" --environment "$UPDATED_ENV" --no-cli-pager > /dev/null
+              echo "Updated $FUNC_NAME"
+            done
+          fi
 
       - name: Get preview URL
         id: url
         run: |
           URL=$(aws cloudformation describe-stacks \
-            --stack-name "${{ needs.resolve.outputs.stack_name }}" \
+            --stack-name "${{ needs.resolve.outputs.frontend_stack }}" \
             --query "Stacks[0].Outputs[?OutputKey=='FrontendUrl'].OutputValue" \
             --output text)
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name "${{ needs.resolve.outputs.api_stack }}" \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" --output text)
           echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "api_url=$API_URL" >> "$GITHUB_OUTPUT"
 
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         with:
           script: |
             const url = '${{ steps.url.outputs.url }}';
+            const apiUrl = '${{ steps.url.outputs.api_url }}';
             const sha = '${{ github.event.pull_request.head.sha }}'.slice(0, 7);
+            const apiStack = '${{ needs.resolve.outputs.api_stack }}';
+            const frontStack = '${{ needs.resolve.outputs.frontend_stack }}';
             const body = [
               '## PR Preview Deployed',
               '',
-              `**URL**: ${url}`,
+              `**Frontend URL**: ${url}`,
+              `**API URL**: ${apiUrl}`,
               '',
-              `Build: \`${sha}\` / Backend: \`${process.env.SHARED_DEV_API_STACK}\` を共有`,
+              `Build: \`${sha}\``,
+              `Stacks: \`${apiStack}\` + \`${frontStack}\``,
               '',
               '> 認証なし（dev/main と同等）。URL は CloudFront ドメインの難読性に依存します。',
               '> このプレビューは PR close で自動削除されます。`preview` ラベルを外すと即時 destroy できます。',
@@ -195,8 +241,6 @@ jobs:
                 body,
               });
             }
-        env:
-          SHARED_DEV_API_STACK: ${{ env.SHARED_DEV_API_STACK }}
 
   destroy:
     name: Destroy preview
@@ -224,38 +268,57 @@ jobs:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Check stack exists
+      - name: Check stacks exist
         id: check
         run: |
-          if aws cloudformation describe-stacks --stack-name "${{ needs.resolve.outputs.stack_name }}" >/dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+          FRONT_EXISTS=false
+          API_EXISTS=false
+          if aws cloudformation describe-stacks --stack-name "${{ needs.resolve.outputs.frontend_stack }}" >/dev/null 2>&1; then
+            FRONT_EXISTS=true
+          fi
+          if aws cloudformation describe-stacks --stack-name "${{ needs.resolve.outputs.api_stack }}" >/dev/null 2>&1; then
+            API_EXISTS=true
+          fi
+          echo "front_exists=$FRONT_EXISTS" >> "$GITHUB_OUTPUT"
+          echo "api_exists=$API_EXISTS" >> "$GITHUB_OUTPUT"
+          if [ "$FRONT_EXISTS" = "false" ] && [ "$API_EXISTS" = "false" ]; then
+            echo "any_exists=false" >> "$GITHUB_OUTPUT"
+            echo "Neither stack exists — skip destroy"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-            echo "Stack ${{ needs.resolve.outputs.stack_name }} not found — skip destroy"
+            echo "any_exists=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build dummy ffmpeg (for cdk synth)
-        if: steps.check.outputs.exists == 'true'
+      - name: Build dummy ffmpeg (for cdk destroy synth)
+        if: steps.check.outputs.any_exists == 'true'
         run: |
           mkdir -p lambda-layers
           [ -f lambda-layers/ffmpeg-layer.zip ] || (echo "dummy" | zip lambda-layers/ffmpeg-layer.zip - >/dev/null)
 
-      - name: Destroy ${{ needs.resolve.outputs.stack_name }}
-        if: steps.check.outputs.exists == 'true'
+      - name: Destroy frontend ${{ needs.resolve.outputs.frontend_stack }}
+        if: steps.check.outputs.front_exists == 'true'
         run: |
-          npx cdk destroy "${{ needs.resolve.outputs.stack_name }}" \
+          npx cdk destroy "${{ needs.resolve.outputs.frontend_stack }}" \
+            -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
+            --force
+
+      - name: Destroy backend ${{ needs.resolve.outputs.api_stack }}
+        if: steps.check.outputs.api_exists == 'true'
+        run: |
+          npx cdk destroy "${{ needs.resolve.outputs.api_stack }}" \
             -c previewPr="${{ needs.resolve.outputs.pr_number }}" \
             --force
 
       - name: Comment destroyed on PR
-        if: steps.check.outputs.exists == 'true'
+        if: steps.check.outputs.any_exists == 'true'
         uses: actions/github-script@v7
         with:
           script: |
+            const apiStack = '${{ needs.resolve.outputs.api_stack }}';
+            const frontStack = '${{ needs.resolve.outputs.frontend_stack }}';
             const body = [
               '## PR Preview Destroyed',
               '',
-              `\`${{ needs.resolve.outputs.stack_name }}\` を削除しました。`,
+              `\`${apiStack}\` + \`${frontStack}\` を削除しました。`,
               '',
               '再度プレビューが必要な場合は `preview` ラベルを再度付与してください。',
             ].join('\n');

--- a/.kiro/steering/architecture.md
+++ b/.kiro/steering/architecture.md
@@ -13,7 +13,7 @@ inclusion: auto
 | dev | `-Dev` | feature/*, bugfix/* | 手動（ローカルから） |
 | staging | `-Staging` | dev | CI/CD自動 |
 | production | (なし) | main | CI/CD自動 |
-| **PR preview** | `-Dev-Pr<num>` | PR ブランチ（`preview` ラベル） | CI/CD自動（frontend のみ、共有 dev backend を参照） |
+| **PR preview** | `-Dev-Pr<num>` | PR ブランチ（`preview` ラベル） | CI/CD自動（backend + frontend 両方、per-PR で完全独立） |
 
 ### 環境分離方式
 - CloudFormationスタック名にサフィックスを付与して同一アカウント内でリソースを分離
@@ -25,7 +25,7 @@ inclusion: auto
 - **dev**: デバッグモード有効、ログレベルDEBUG
 - **staging**: デバッグモード無効、ログレベルINFO、本番同等設定
 - **production**: デバッグモード無効、ログレベルINFO、最適化済み
-- **PR preview**: `FrontendStack-Dev-Pr<num>` のみ独立、API URL は dev backend を共有。認証なし (dev/main と同等、URL 難読性に依存)。PR close または 7日 idle で自動 destroy（issue #87）
+- **PR preview**: `ImageProcessorApiStack-Dev-Pr<num>` + `FrontendStack-Dev-Pr<num>` を per-PR で完全独立に作成。frontend は自身の per-PR backend を参照するため front + back の full E2E が実行可能。認証なし (dev/main と同等、URL 難読性に依存)。PR close または 7日 idle で frontend → backend の順で自動 destroy（issue #87）
 
 ## サーバーレス原則
 

--- a/.kiro/steering/testing.md
+++ b/.kiro/steering/testing.md
@@ -74,8 +74,8 @@ npm run test:all-e2e
 
 - CI/CDパイプライン（`deploy.yml`）がデプロイ後に `e2e-test.yml` を自動呼び出し
 - 手動トリガー: Actions → E2E Test → Run workflow → 環境・テストスイート選択
-- **PR Preview**（`pr-preview.yml`）: `preview` ラベル付きの PR で frontend を ephemeral デプロイ → PR コメントに URL を投稿。認証なし (dev/main と同等)。PR close / ラベル解除で自動 destroy（issue #87）
-- **Stale Preview Cleanup**（`cleanup-stale-previews.yml`）: 日次 cron (UTC 18:00) で 7 日 idle の `FrontendStack-Dev-Pr*` を destroy
+- **PR Preview**（`pr-preview.yml`）: `preview` ラベル付きの PR で backend + frontend を per-PR で ephemeral デプロイ（完全独立、full E2E 可能） → PR コメントに Frontend/API URL を投稿。認証なし (dev/main と同等)。PR close / ラベル解除で frontend → backend の順で自動 destroy（issue #87）
+- **Stale Preview Cleanup**（`cleanup-stale-previews.yml`）: 日次 cron (UTC 18:00) で 7 日 idle の preview スタック組（`FrontendStack-Dev-Pr*` + `ImageProcessorApiStack-Dev-Pr*`）を frontend → backend の順で destroy
 
 ## テストコマンド
 

--- a/.kiro/steering/workflow.md
+++ b/.kiro/steering/workflow.md
@@ -104,29 +104,31 @@ dev環境デプロイ後のe2eテスト手順は [testing.md](testing.md) の「
 - レビュー → フィードバック対応
 - **devブランチへのマージは指示があるまで行わない**
 
-#### PR Preview（UI 変更を含む PR の実機レビュー） — issue #87
+#### PR Preview（実機レビュー + full E2E） — issue #87
 
-`frontend/` 配下の変更を含む PR で UI 動作確認が必要な場合、PR に `preview` ラベルを付与すると ephemeral preview 環境が自動で立ち上がる:
+UI/API いずれかの変更を含む PR で実機確認が必要な場合、PR に `preview` ラベルを付与すると per-PR の独立 ephemeral 環境（backend + frontend）が自動で立ち上がる:
 
 ```
 PR open / push / label "preview" 追加
   ↓ .github/workflows/pr-preview.yml
-  ├ build frontend (config.json は共有 dev backend を指す)
+  ├ cdk deploy ImageProcessorApiStack-Dev-Pr<num>（API + Lambda + DDB + S3）
+  ├ config.json を per-PR backend の URL で生成 + frontend build
   ├ cdk deploy FrontendStack-Dev-Pr<num>（CloudFront + S3）
-  └ PR コメントに URL を自動投稿
+  ├ Lambda CLOUDFRONT_DOMAIN を per-PR Distribution に更新
+  └ PR コメントに Frontend URL + API URL を自動投稿
 ```
 
-レビュアーは PR コメントの URL から実機にアクセスして UI を確認できる。`preview` ラベルを外す or PR を close すると自動 destroy。さらに 7 日 idle のスタックは日次 cleanup ワークフローで自動削除される。
+レビュアーは PR コメントの URL から実機にアクセスし、front + backend を含む full E2E を実行できる。`preview` ラベルを外す or PR を close すると frontend → backend の順で自動 destroy。さらに 7 日 idle のスタックは日次 cleanup ワークフローで自動削除される。
 
 **認証**: dev/main と同様に無し。CloudFront ドメインの難読性に依存（限定共有用途）。
 
 **前提**:
-- `ImageProcessorApiStack-Dev`（共有 dev backend）が存在すること
 - repo secrets: `AWS_DEPLOY_ROLE_ARN`
+- `AWS_DEPLOY_ROLE_ARN` が `ImageProcessorApiStack-Dev-Pr*` / `FrontendStack-Dev-Pr*` の create/update/delete 権限を持つこと
 
 **スコープ**:
-- frontend stack のみ deploy（backend は共有 dev を参照）
-- backend 変更を含む PR は staging まで進めて確認する
+- backend + frontend の両方を per-PR で独立に作成（共有 backend は使わない）
+- backend 変更を含む PR でも full E2E が可能
 
 ### ステップ8: devへマージ → staging環境で統合テスト
 - 指示を受けてからdevにマージ

--- a/bin/image-processor-api.ts
+++ b/bin/image-processor-api.ts
@@ -15,8 +15,9 @@ const env = {
 };
 
 // PR preview モード（issue #87）:
-//   -c previewPr=<num> を渡すと、共有 dev backend を参照する単独 frontend stack
-//   `FrontendStack-Dev-Pr<num>` のみを作成する。バックエンドは作成しない。
+//   -c previewPr=<num> を渡すと、`ImageProcessorApiStack-Dev-Pr<num>` +
+//   `FrontendStack-Dev-Pr<num>` の両スタックを per-PR で作成する。
+//   frontend は自身の per-PR backend を参照する（共有 dev backend は使わない）。
 //   認証は dev/main と同じく無し（CloudFront URL の難読性に依存）。
 const previewPr = app.node.tryGetContext('previewPr') as string | undefined;
 
@@ -34,26 +35,29 @@ if (previewPr) {
     resourceSuffix: previewResourceSuffix,
     isProduction: false,
   };
-  // 参照先（共有 dev backend）の envConfig
-  const sharedDevConfig: EnvironmentConfig = {
-    name: 'dev',
-    suffix: '-Dev',
-    resourceSuffix: '-dev',
-    isProduction: false,
+  const previewTags = {
+    Project: 'ImageProcessorAPI',
+    Version: 'v2',
+    Environment: 'dev',
+    PreviewPR: previewPr,
   };
 
-  new FrontendStack(app, `FrontendStack${previewSuffix}`, {
-    description: `PR #${previewPr} Preview Frontend (shared dev backend)`,
+  // backend (per-PR)
+  const previewApiStack = new ImageProcessorApiStack(app, `ImageProcessorApiStack${previewSuffix}`, {
+    description: `PR #${previewPr} Preview Backend`,
     env,
-    tags: {
-      Project: 'ImageProcessorAPI',
-      Version: 'v2',
-      Environment: 'dev',
-      PreviewPR: previewPr,
-    },
+    tags: previewTags,
     envConfig: previewEnvConfig,
-    importEnvConfig: sharedDevConfig,
   });
+
+  // frontend (per-PR) — 自身の per-PR backend を参照（importEnvConfig 省略で envConfig 自身を使う）
+  const previewFrontendStack = new FrontendStack(app, `FrontendStack${previewSuffix}`, {
+    description: `PR #${previewPr} Preview Frontend`,
+    env,
+    tags: previewTags,
+    envConfig: previewEnvConfig,
+  });
+  previewFrontendStack.addDependency(previewApiStack);
 } else {
   // 通常モード: backend + frontend を envConfig.suffix で作成
   const envConfig = resolveEnvironment(app);


### PR DESCRIPTION
issue #87 の MVP（PR #97）拡張版。preview 環境を backend + frontend の完全独立に変更し、frontend + backend を含む full E2E を preview 上で回せるようにする。

## 仕組み

```
PR open / push / label "preview"
  ↓ .github/workflows/pr-preview.yml
  ├ cdk deploy ImageProcessorApiStack-Dev-Pr<num>（API + Lambda + DDB + S3 etc.）
  ├ config.json は per-PR backend の URL で生成
  ├ frontend build → cdk deploy FrontendStack-Dev-Pr<num>
  ├ Lambda CLOUDFRONT_DOMAIN を per-PR Distribution に更新
  └ PR コメントに Frontend URL + API URL を自動投稿

PR close / preview ラベル解除
  ↓
  └ frontend → backend の順で cdk destroy

cron daily UTC 18:00
  ↓
  └ 7 日 idle の PR グループ（frontend + backend）を frontend → backend で destroy
```

## 主な変更

### `bin/image-processor-api.ts`
- preview mode で `ImageProcessorApiStack-Dev-Pr<num>` + `FrontendStack-Dev-Pr<num>` 両方を生成
- `FrontendStack` は `importEnvConfig` を省略 → `envConfig` (自身 = per-PR) を参照
- 通常モード (dev/staging/production) のコードパスは無変更

### `.github/workflows/pr-preview.yml`
- `resolve` job: outputs を `api_stack` / `frontend_stack` に分離
- `deploy` job:
  - backend deploy → CFN Output から API URL 取得 → `config.json` 生成 → frontend build → frontend deploy
  - Lambda `CLOUDFRONT_DOMAIN` env を per-PR Distribution に更新（CFN リソースから物理 ID 取得方式で 64字制限耐性）
  - PR コメントに **Frontend URL + API URL** を投稿
  - timeout 20→30 分（backend deploy 分の余裕）
- `destroy` job: frontend → backend の順、両 stack の存在を独立に確認

### `.github/workflows/cleanup-stale-previews.yml`
- preview stack を frontend + backend の両 prefix で取得
- **PR 番号セットで集約**、各 PR の LastUpdatedTime (frontend / backend の最新値) で stale 判定
- destroy も frontend → backend の順

### Docs (architecture / testing / workflow)
- 「frontend のみ / 共有 dev backend」→「backend + frontend per-PR 完全独立」に書き換え

## 検証

- [x] ローカル CDK list で `ImageProcessorApiStack-Dev-Pr99` + `FrontendStack-Dev-Pr99` 両方が生成されることを確認
- [x] 通常モードのコードパスは無変更（CI synth で再検証）
- [ ] CI 4/4 pass
- [ ] マージ後、本 PR 自体に `preview` ラベル付与で full E2E dogfooding

## マージ前の確認事項

`AWS_DEPLOY_ROLE_ARN` の IAM 権限が `ImageProcessorApiStack-Dev-Pr*` / `FrontendStack-Dev-Pr*` の create/update/delete + 含まれる全リソース（Lambda, API Gateway, S3, DDB, CloudFront）の操作権限を持つこと。staging/production のデプロイ権限を持つ role であれば通常は問題なし。

## 関連
- #87 (本 issue)
- PR #97 (frontend のみ ephemeral 版、本 PR で full stack 化)

🤖 Generated with [Claude Code](https://claude.com/claude-code)