### PR TITLE
fix(cdk): TestImagesBucket に autoDeleteObjects: true を追加

### DIFF
--- a/lib/image-processor-api-stack.ts
+++ b/lib/image-processor-api-stack.ts
@@ -50,6 +50,9 @@ export class ImageProcessorApiStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
+      // PR preview destroy で「bucket not empty」エラーになる事象 (PR #99) を防ぐ。
+      // UploadBucket と同じパターン。removalPolicy: DESTROY と必ずセットで使う。
+      autoDeleteObjects: true,
     });
 
 


### PR DESCRIPTION
PR #99 マージ後の preview destroy が「bucket not empty」で失敗した事象の根本対処。

## 原因
- \`pr-preview.yml\` が backend deploy 直後に \`upload-test-images.sh\` で TestImagesBucket に画像を投入
- destroy 時に object 残存で S3 が 409 を返す
- TestImagesBucket は \`removalPolicy: DESTROY\` だが \`autoDeleteObjects\` が抜けていた
- UploadBucket は両方設定済みで問題なし

## 変更
\`lib/image-processor-api-stack.ts\`: TestImagesBucket に \`autoDeleteObjects: true\` を 1 行追加。UploadBucket と同じパターン。

## 影響
- dev/staging/production すべて \`removalPolicy: DESTROY\` のため autoDelete を有効化しても従来挙動と整合
- production は通常 destroy しないため実害なし
- 今後の PR preview destroy が安定する

## 検証
- [x] CDK Build OK
- [ ] CI 4/4 pass
- [ ] マージ後 dev に反映 → 次回 PR preview cycle で destroy 成功確認

## 並行対処
PR #99 で発生した孤児スタック \`ImageProcessorApiStack-Dev-Pr99\` は手動 emptying + delete-stack で除去済み。

Refs: PR #99, #87