### PR TITLE
feat(settings): SettingsPage デフォルト/プリセット UI (issue #59 Phase 2)

### DIFF
--- a/.kiro/specs/image-composition/tasks.md
+++ b/.kiro/specs/image-composition/tasks.md
@@ -546,3 +546,40 @@
   - dev からの最新を逆マージしてマージ
   - PR テンプレート（`.github/pull_request_template.md`）のチェックリストを完了
   - _要件: 21.8, 21.9_
+## Issue #59 Phase 2: SettingsPage デフォルト/プリセット UI
+
+### タスク22: Preset 型定義と compositeDefaults 拡張
+_要件: プリセット機能（issue #59）_
+
+- [x] 22.1 `compositeDefaults.ts` に `PresetTextOverlay` / `Preset` インターフェース追加
+- [x] 22.2 `CompositeDefaults.presets` を `Record<string, Preset>` に変更
+- [x] 22.3 `presets` computed ゲッターを追加して return に公開
+
+### タスク23: userDefaults ストア新設
+_要件: localStorage 上書き管理（issue #59）_
+
+- [x] 23.1 `stores/userDefaults.ts` 新規作成（UserDefaults 型 / applyPreset / reset）
+- [x] 23.2 `stores/__tests__/userDefaults.test.ts` ユニットテスト作成（5件）
+- [x] 23.3 localStorage キー `composite-user-defaults` への保存/復元/削除を実装
+
+### タスク24: App.vue に userDefaults 優先チェーン適用
+_要件: system_default < userDefaults < UI明示指定 の優先順（issue #59）_
+
+- [x] 24.1 `App.vue` に `useUserDefaultsStore` を追加
+- [x] 24.2 `applyUserOverrides()` 関数追加（baseImage / baseOpacity の上書き）
+- [x] 24.3 `onMounted` 内で `applyCompositeDefaults()` → `applyUserOverrides()` の順で呼び出し
+
+### タスク25: DefaultsTab.vue 新規作成
+_要件: SettingsPage デフォルトタブ UI（issue #59）_
+
+- [x] 25.1 `components/settings/DefaultsTab.vue` 新規作成
+- [x] 25.2 プリセット一覧（live/promo/subtitle カード表示）と「適用」ボタン
+- [x] 25.3 現在のユーザー上書き表示 + 「リセット」ボタン
+- [x] 25.4 システムデフォルト読み取り専用表示（baseImage/baseOpacity/canvas/video）
+
+### タスク26: SettingsPage.vue にデフォルトタブを追加
+_要件: 3番目のタブ追加（issue #59）_
+
+- [x] 26.1 `activeTab` 型に `'defaults'` を追加
+- [x] 26.2 「デフォルト」タブボタンを追加（モデル / ルール / デフォルト）
+- [x] 26.3 `DefaultsTab` コンポーネントをインポートして `v-else-if="activeTab === 'defaults'"` で表示

--- a/docs/superpowers/plans/2026-06-15-issue59-phase2-settings-ui.md
+++ b/docs/superpowers/plans/2026-06-15-issue59-phase2-settings-ui.md
@@ -1,0 +1,600 @@
+# Issue #59 Phase 2 — SettingsPage デフォルト/プリセット UI 実装計画
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** SettingsPage に「デフォルト」タブを追加し、composite-default.json のプリセット一覧表示・ユーザー個別上書き（localStorage）・リセット機能を実装する。
+
+**Architecture:** `compositeDefaults.ts` に `Preset` 型を追加（読み取り専用）。新設 `userDefaults.ts` が localStorage への上書き値を管理する。App.vue が `applyCompositeDefaults()` → `applyUserOverrides()` の順で初期値を適用することで「system_default < userDefaults < UI明示指定」の優先チェーンを保証する。
+
+**Tech Stack:** Vue 3 (Composition API) / Pinia / TypeScript / Vitest / Tailwind CSS
+
+---
+
+## ファイル構成
+
+| 操作 | ファイル | 責務 |
+|------|---------|------|
+| 修正 | `frontend/src/stores/compositeDefaults.ts` | `Preset` / `PresetTextOverlay` 型追加、`presets` ゲッター追加 |
+| 新規 | `frontend/src/stores/userDefaults.ts` | localStorage上書き管理（baseImage / baseOpacity）、applyPreset / reset |
+| 新規 | `frontend/src/stores/__tests__/userDefaults.test.ts` | userDefaults ストアのユニットテスト |
+| 修正 | `frontend/src/stores/__tests__/compositeDefaults.test.ts` | presets 型のテスト追加 |
+| 修正 | `frontend/src/App.vue` | applyUserOverrides() 追加、onMounted で呼び出し |
+| 新規 | `frontend/src/components/settings/DefaultsTab.vue` | プリセットカード一覧 + ユーザー上書き表示 + リセット |
+| 修正 | `frontend/src/pages/SettingsPage.vue` | 'defaults' タブ追加、DefaultsTab 参照 |
+
+---
+
+## Task 1: compositeDefaults.ts に Preset 型を追加
+
+**Files:**
+- Modify: `frontend/src/stores/compositeDefaults.ts`
+
+- [ ] **Step 1: Preset 型と presets ゲッターを追加**
+
+`frontend/src/stores/compositeDefaults.ts` の `TextPlaceholder` 定義の直後（28行目付近）に以下を追加し、`CompositeDefaults` の `presets` フィールドを強化する：
+
+```typescript
+export interface PresetTextOverlay {
+  text: string
+  position: string
+  font_size: number
+  font_color: string
+  bg_color: string | null
+  bg_opacity?: number
+}
+
+export interface Preset {
+  description: string
+  baseImage: string
+  baseOpacity: number
+  image_placement: Partial<Record<ImageKey, ImagePosition>>
+  text_overlays: Record<string, PresetTextOverlay>
+}
+```
+
+`CompositeDefaults` インターフェース（46行目）の `presets` フィールドを変更：
+```typescript
+// 変更前
+export interface CompositeDefaults {
+  version: string
+  system_default: SystemDefault
+  presets: Record<string, unknown>
+}
+
+// 変更後
+export interface CompositeDefaults {
+  version: string
+  system_default: SystemDefault
+  presets: Record<string, Preset>
+}
+```
+
+`defineStore` 内の `systemDefault` computed の直後に `presets` computed を追加：
+```typescript
+const presets = computed(() => defaults.value?.presets ?? {})
+```
+
+`return` ブロックに `presets` を追加：
+```typescript
+return {
+  defaults,
+  isLoaded,
+  systemDefault,
+  presets,          // ← 追加
+  loadDefaults,
+  determineImageMode,
+  getImageDefault,
+  getTextPlaceholder,
+}
+```
+
+- [ ] **Step 2: 既存テストが通ることを確認**
+
+```bash
+cd frontend && npm test -- --run src/stores/__tests__/compositeDefaults.test.ts
+```
+
+Expected: all tests PASS（`presets: {}` のサンプルはそのまま互換）
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/stores/compositeDefaults.ts
+git commit -m "feat(stores): compositeDefaults に Preset 型と presets ゲッターを追加 (issue #59)"
+```
+
+---
+
+## Task 2: userDefaults.ts 新設とユニットテスト
+
+**Files:**
+- Create: `frontend/src/stores/userDefaults.ts`
+- Create: `frontend/src/stores/__tests__/userDefaults.test.ts`
+
+- [ ] **Step 1: 失敗テストを書く**
+
+`frontend/src/stores/__tests__/userDefaults.test.ts` を新規作成：
+
+```typescript
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUserDefaultsStore } from '@/stores/userDefaults'
+import type { Preset } from '@/stores/compositeDefaults'
+
+const SAMPLE_PRESET: Preset = {
+  description: 'ライブ配信用',
+  baseImage: '#000000',
+  baseOpacity: 100,
+  image_placement: { image1: { x: 760, y: 290, width: 400, height: 400 } },
+  text_overlays: {
+    text1: { text: 'LIVE', position: '1800,80', font_size: 56, font_color: '#FF0000', bg_color: null },
+  },
+}
+
+describe('useUserDefaultsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('初期状態では overrides は空オブジェクト', () => {
+    const store = useUserDefaultsStore()
+    expect(store.overrides).toEqual({})
+    expect(store.hasOverrides).toBe(false)
+  })
+
+  it('applyPreset で baseImage/baseOpacity を localStorage に保存する', () => {
+    const store = useUserDefaultsStore()
+    store.applyPreset(SAMPLE_PRESET)
+    expect(store.overrides.baseImage).toBe('#000000')
+    expect(store.overrides.baseOpacity).toBe(100)
+    expect(store.hasOverrides).toBe(true)
+    const saved = JSON.parse(localStorage.getItem('composite-user-defaults') ?? '{}')
+    expect(saved.baseImage).toBe('#000000')
+  })
+
+  it('reset() で overrides をクリアし localStorage を削除する', () => {
+    const store = useUserDefaultsStore()
+    store.applyPreset(SAMPLE_PRESET)
+    store.reset()
+    expect(store.overrides).toEqual({})
+    expect(store.hasOverrides).toBe(false)
+    expect(localStorage.getItem('composite-user-defaults')).toBeNull()
+  })
+
+  it('localStorage に保存済み値があれば初期化時に復元する', () => {
+    localStorage.setItem('composite-user-defaults', JSON.stringify({ baseImage: '#FFFFFF', baseOpacity: 80 }))
+    const store = useUserDefaultsStore()
+    expect(store.overrides.baseImage).toBe('#FFFFFF')
+    expect(store.overrides.baseOpacity).toBe(80)
+  })
+
+  it('localStorage が壊れていてもエラーにならず空オブジェクトを返す', () => {
+    localStorage.setItem('composite-user-defaults', 'invalid json{')
+    const store = useUserDefaultsStore()
+    expect(store.overrides).toEqual({})
+  })
+})
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+```bash
+cd frontend && npm test -- --run src/stores/__tests__/userDefaults.test.ts
+```
+
+Expected: FAIL with "Cannot find module '@/stores/userDefaults'"
+
+- [ ] **Step 3: userDefaults.ts を実装**
+
+`frontend/src/stores/userDefaults.ts` を新規作成：
+
+```typescript
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type { Preset } from './compositeDefaults'
+
+const STORAGE_KEY = 'composite-user-defaults'
+
+export interface UserDefaults {
+  baseImage?: string
+  baseOpacity?: number
+}
+
+function loadFromStorage(): UserDefaults {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as UserDefaults) : {}
+  } catch {
+    return {}
+  }
+}
+
+export const useUserDefaultsStore = defineStore('userDefaults', () => {
+  const overrides = ref<UserDefaults>(loadFromStorage())
+
+  const hasOverrides = computed(
+    () => overrides.value.baseImage !== undefined || overrides.value.baseOpacity !== undefined,
+  )
+
+  function applyPreset(preset: Preset): void {
+    overrides.value = {
+      baseImage: preset.baseImage,
+      baseOpacity: preset.baseOpacity,
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides.value))
+  }
+
+  function reset(): void {
+    overrides.value = {}
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  return { overrides, hasOverrides, applyPreset, reset }
+})
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+```bash
+cd frontend && npm test -- --run src/stores/__tests__/userDefaults.test.ts
+```
+
+Expected: 5 tests PASS
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/stores/userDefaults.ts frontend/src/stores/__tests__/userDefaults.test.ts
+git commit -m "feat(stores): userDefaults ストア新設 — localStorage上書き管理 (issue #59)"
+```
+
+---
+
+## Task 3: App.vue に userOverrides 適用を追加
+
+**Files:**
+- Modify: `frontend/src/App.vue`
+
+- [ ] **Step 1: import と store 初期化を追加**
+
+`frontend/src/App.vue` の `script setup` ブロック内、`compositeDefaultsStore` の初期化行（151行目付近）の直後に追加：
+
+```typescript
+import { useUserDefaultsStore } from '@/stores/userDefaults'
+// ...（既存 import 群の末尾付近）
+const userDefaultsStore = useUserDefaultsStore()
+```
+
+- [ ] **Step 2: applyUserOverrides() 関数を追加**
+
+`applyCompositeDefaults()` 関数（833行目付近）の直後に追加：
+
+```typescript
+function applyUserOverrides(): void {
+  const ud = userDefaultsStore.overrides
+  if (ud.baseImage !== undefined) params.value.baseImage = ud.baseImage
+  if (ud.baseOpacity !== undefined) params.value.baseOpacity = ud.baseOpacity
+}
+```
+
+- [ ] **Step 3: onMounted で applyUserOverrides() を呼び出す**
+
+`onMounted` 内の `applyCompositeDefaults()` 呼び出し（889行目）の直後に追加：
+
+```typescript
+applyCompositeDefaults()
+applyUserOverrides()  // ← 追加
+```
+
+- [ ] **Step 4: 開発サーバーで動作確認**
+
+```bash
+cd frontend && npm run dev
+```
+
+1. ブラウザで `http://localhost:5173` を開く
+2. localStorage に `composite-user-defaults` キーを手動で設定（DevTools → Application → LocalStorage）：
+   `{"baseImage":"#FF0000","baseOpacity":50}`
+3. ページをリロードして背景色が赤・不透明度が50%になることを確認
+4. localStorage を削除してリロードし、通常のデフォルト（`#000000`, 100%）に戻ることを確認
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/App.vue
+git commit -m "feat(app): userDefaults の上書き値を起動時に反映 (issue #59)"
+```
+
+---
+
+## Task 4: DefaultsTab.vue 新規作成
+
+**Files:**
+- Create: `frontend/src/components/settings/DefaultsTab.vue`
+
+- [ ] **Step 1: DefaultsTab.vue を実装**
+
+`frontend/src/components/settings/DefaultsTab.vue` を新規作成：
+
+```vue
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useCompositeDefaultsStore } from '@/stores/compositeDefaults'
+import { useUserDefaultsStore } from '@/stores/userDefaults'
+import type { Preset } from '@/stores/compositeDefaults'
+
+const compositeStore = useCompositeDefaultsStore()
+const userStore = useUserDefaultsStore()
+
+onMounted(async () => {
+  if (!compositeStore.isLoaded) {
+    await compositeStore.loadDefaults()
+  }
+})
+
+function applyPreset(preset: Preset) {
+  userStore.applyPreset(preset)
+}
+
+function reset() {
+  userStore.reset()
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+
+    <!-- プリセット一覧 -->
+    <section class="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+      <h2 class="text-sm font-medium text-gray-700 mb-1">プリセット</h2>
+      <p class="text-xs text-gray-500 mb-4">
+        典型的な配置パターンを適用すると、背景色と不透明度のデフォルト値が更新されます。
+      </p>
+
+      <div v-if="!compositeStore.isLoaded" class="text-sm text-gray-400">読み込み中...</div>
+
+      <div v-else-if="Object.keys(compositeStore.presets).length === 0" class="text-sm text-gray-400">
+        プリセットが定義されていません。
+      </div>
+
+      <div v-else class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div
+          v-for="(preset, name) in compositeStore.presets"
+          :key="name"
+          class="rounded-lg border border-gray-200 p-4 flex flex-col gap-3 bg-gray-50"
+        >
+          <div class="flex-1">
+            <h3 class="text-sm font-semibold text-gray-800 capitalize">{{ name }}</h3>
+            <p class="text-xs text-gray-500 mt-1">{{ preset.description }}</p>
+            <div class="mt-2 flex items-center gap-2 text-xs text-gray-600">
+              <span class="inline-flex items-center gap-1">
+                <span
+                  class="w-3 h-3 rounded-sm border border-gray-300 inline-block"
+                  :style="preset.baseImage.startsWith('#') ? { background: preset.baseImage } : { background: 'transparent' }"
+                />
+                {{ preset.baseImage === 'transparent' ? '透明' : preset.baseImage }}
+              </span>
+              <span>/ 不透明度 {{ preset.baseOpacity }}%</span>
+            </div>
+          </div>
+          <button
+            class="text-xs px-3 py-1.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors self-start"
+            @click="applyPreset(preset)"
+          >
+            適用
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- 現在のユーザー上書き -->
+    <section class="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+      <div class="flex items-center justify-between mb-3">
+        <div>
+          <h2 class="text-sm font-medium text-gray-700">現在のユーザー上書き</h2>
+          <p class="text-xs text-gray-500 mt-0.5">localStorage に保存されたデフォルト上書き値</p>
+        </div>
+        <button
+          v-if="userStore.hasOverrides"
+          class="text-xs px-3 py-1.5 bg-gray-100 text-gray-600 rounded hover:bg-gray-200 transition-colors"
+          @click="reset"
+        >
+          リセット
+        </button>
+      </div>
+
+      <div v-if="!userStore.hasOverrides" class="text-sm text-gray-400">
+        上書き設定なし（システムデフォルトを使用中）
+      </div>
+      <div v-else class="space-y-2 text-sm">
+        <div v-if="userStore.overrides.baseImage !== undefined" class="flex items-center gap-3">
+          <span class="text-gray-500 w-28 shrink-0">背景色</span>
+          <span class="inline-flex items-center gap-2">
+            <span
+              class="w-4 h-4 rounded-sm border border-gray-300"
+              :style="userStore.overrides.baseImage.startsWith('#')
+                ? { background: userStore.overrides.baseImage }
+                : { background: 'transparent' }"
+            />
+            <span class="font-mono text-gray-800">{{ userStore.overrides.baseImage }}</span>
+          </span>
+        </div>
+        <div v-if="userStore.overrides.baseOpacity !== undefined" class="flex items-center gap-3">
+          <span class="text-gray-500 w-28 shrink-0">不透明度</span>
+          <span class="font-mono text-gray-800">{{ userStore.overrides.baseOpacity }}%</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- システムデフォルト（読み取り専用） -->
+    <section class="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+      <h2 class="text-sm font-medium text-gray-700 mb-1">システムデフォルト</h2>
+      <p class="text-xs text-gray-500 mb-3">composite-default.json の system_default 値（読み取り専用）</p>
+
+      <div v-if="!compositeStore.systemDefault" class="text-sm text-gray-400">読み込み中...</div>
+      <dl v-else class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">背景色</dt>
+          <dd class="flex items-center gap-2">
+            <span
+              class="w-4 h-4 rounded-sm border border-gray-300"
+              :style="compositeStore.systemDefault.baseImage.startsWith('#')
+                ? { background: compositeStore.systemDefault.baseImage }
+                : { background: 'transparent' }"
+            />
+            <span class="font-mono text-gray-800">{{ compositeStore.systemDefault.baseImage }}</span>
+          </dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">不透明度</dt>
+          <dd class="font-mono text-gray-800">{{ compositeStore.systemDefault.baseOpacity }}%</dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">キャンバス</dt>
+          <dd class="font-mono text-gray-800">
+            {{ compositeStore.systemDefault.canvas.width }}×{{ compositeStore.systemDefault.canvas.height }}
+          </dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">動画形式</dt>
+          <dd class="font-mono text-gray-800">
+            {{ compositeStore.systemDefault.video.format }} / {{ compositeStore.systemDefault.video.duration }}秒
+          </dd>
+        </div>
+      </dl>
+    </section>
+
+  </div>
+</template>
+```
+
+- [ ] **Step 2: コミット**
+
+```bash
+git add frontend/src/components/settings/DefaultsTab.vue
+git commit -m "feat(settings): DefaultsTab.vue 新規作成 — プリセット一覧 + ユーザー上書き + システムデフォルト表示 (issue #59)"
+```
+
+---
+
+## Task 5: SettingsPage.vue に「デフォルト」タブを追加
+
+**Files:**
+- Modify: `frontend/src/pages/SettingsPage.vue`
+
+- [ ] **Step 1: 'defaults' タブを追加**
+
+`frontend/src/pages/SettingsPage.vue` の `activeTab` 型定義（123行目）を変更：
+
+```typescript
+// 変更前
+const activeTab = ref<'model' | 'rules'>('model')
+
+// 変更後
+const activeTab = ref<'model' | 'rules' | 'defaults'>('model')
+```
+
+`script setup` ブロックの import 群に追加：
+
+```typescript
+import DefaultsTab from '@/components/settings/DefaultsTab.vue'
+```
+
+- [ ] **Step 2: タブボタンを追加**
+
+`<template>` のタブ切替 `div`（13行目付近）内、`rules` タブボタンの直後に追加：
+
+```html
+<button
+  class="px-4 py-2 text-sm font-medium transition-colors"
+  :class="activeTab === 'defaults'
+    ? 'text-blue-600 border-b-2 border-blue-500'
+    : 'text-gray-500 hover:text-gray-700'"
+  @click="activeTab = 'defaults'"
+>
+  デフォルト
+</button>
+```
+
+- [ ] **Step 3: DefaultsTab の表示ブロックを追加**
+
+`</template>` 閉じタグの直前（ルール管理タブの `</template>` の直後）に追加：
+
+```html
+<!-- デフォルト/プリセットタブ -->
+<section v-else-if="activeTab === 'defaults'">
+  <DefaultsTab />
+</section>
+```
+
+- [ ] **Step 4: 開発サーバーで動作確認**
+
+```bash
+cd frontend && npm run dev
+```
+
+1. `http://localhost:5173/chat/settings` を開く
+2. 「デフォルト」タブが表示されることを確認
+3. プリセット（live / promo / subtitle）の3枚カードが表示されることを確認
+4. 「適用」ボタンを押すと「現在のユーザー上書き」セクションに値が反映されることを確認
+5. 「リセット」ボタンを押すと「上書き設定なし」に戻ることを確認
+6. `/api` ページに遷移し、背景色・不透明度の初期値がプリセット適用値になっていることを確認
+7. DevTools → LocalStorage → `composite-user-defaults` キーで保存値を確認
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/pages/SettingsPage.vue
+git commit -m "feat(settings): SettingsPage に「デフォルト」タブ追加 (issue #59 Phase 2)"
+```
+
+---
+
+## Task 6: tasks.md 更新と PR 作成準備
+
+**Files:**
+- Modify: `.kiro/specs/image-composition/tasks.md`（Phase 2 タスクがある場合）
+
+- [ ] **Step 1: 全テストを通す**
+
+```bash
+cd frontend && npm test -- --run
+```
+
+Expected: userDefaults テスト 5件 + compositeDefaults テスト 既存全件 PASS
+
+- [ ] **Step 2: TypeScript エラーがないことを確認**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+Expected: エラーなし（0 errors）
+
+- [ ] **Step 3: 最終コミット（tasks.md 更新）**
+
+`.kiro/specs/image-composition/tasks.md` に Phase 2 の完了状態を反映（既存タスクのチェックボックスを `[x]` に更新）してコミット：
+
+```bash
+git add .kiro/specs/image-composition/tasks.md
+git commit -m "docs(tasks): issue #59 Phase 2 タスク完了マーク"
+```
+
+---
+
+## Self-Review チェックリスト
+
+- [x] Preset 型 → Task 1 で定義、Task 2/4 で参照
+- [x] UserDefaults 型 → Task 2 で定義、Task 3/4 で参照
+- [x] `applyPreset` シグネチャ一致 → Task 2 で定義、Task 4 で呼び出し
+- [x] `hasOverrides` → Task 2 で定義、Task 4 テンプレートで使用
+- [x] localStorage キー `'composite-user-defaults'` → Task 2 で定数化、Task 2 テストで検証
+- [x] `compositeStore.presets` ゲッター → Task 1 で追加、Task 4 で参照
+- [x] `applyCompositeDefaults()` → `applyUserOverrides()` の順序 → Task 3 で確認
+- [x] システムデフォルト表示が読み取り専用 → DefaultsTab に編集フォームなし
+- [x] image_placement の上書きは扱わない（チャット/Agent Tools 専用）→ `UserDefaults` に含まない

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -135,6 +135,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { useConfigStore } from '@/stores/config'
 import { useCompositeDefaultsStore } from '@/stores/compositeDefaults'
+import { useUserDefaultsStore } from '@/stores/userDefaults'
 import { useNotificationStore } from '@/stores/notification'
 import NotificationSystem from '@/components/NotificationSystem.vue'
 import LoadingOverlay from '@/components/LoadingOverlay.vue'
@@ -149,6 +150,7 @@ import axios from 'axios'
 const appStore = useAppStore()
 const configStore = useConfigStore()
 const compositeDefaultsStore = useCompositeDefaultsStore()
+const userDefaultsStore = useUserDefaultsStore()
 const notificationStore = useNotificationStore()
 
 // パラメータ（1920x1080固定キャンバス）
@@ -871,6 +873,12 @@ function applyCompositeDefaults() {
   textConfigs.value.text3 = { ...textConfigs.value.text3, x: tps.text3.x, y: tps.text3.y, fontSize: tps.text3.font_size }
 }
 
+function applyUserOverrides(): void {
+  const ud = userDefaultsStore.overrides
+  if (ud.baseImage !== undefined) params.value.baseImage = ud.baseImage
+  if (ud.baseOpacity !== undefined) params.value.baseOpacity = ud.baseOpacity
+}
+
 // ライフサイクル
 onMounted(async () => {
   try {
@@ -887,6 +895,7 @@ onMounted(async () => {
       await compositeDefaultsStore.loadDefaults()
     }
     applyCompositeDefaults()
+    applyUserOverrides()
 
     console.log('[App] Application initialized successfully')
   } catch (error) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -131,7 +131,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, watch } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { useConfigStore } from '@/stores/config'
 import { useCompositeDefaultsStore } from '@/stores/compositeDefaults'
@@ -878,6 +878,8 @@ function applyUserOverrides(): void {
   if (ud.baseImage !== undefined) params.value.baseImage = ud.baseImage
   if (ud.baseOpacity !== undefined) params.value.baseOpacity = ud.baseOpacity
 }
+
+watch(() => userDefaultsStore.overrides, applyUserOverrides, { deep: true })
 
 // ライフサイクル
 onMounted(async () => {

--- a/frontend/src/components/settings/DefaultsTab.vue
+++ b/frontend/src/components/settings/DefaultsTab.vue
@@ -88,7 +88,7 @@ function reset() {
         上書き設定なし（システムデフォルトを使用中）
       </div>
       <div v-else class="space-y-2 text-sm">
-        <div v-if="userStore.overrides.baseImage !== undefined" class="flex items-center gap-3">
+        <div v-if="typeof userStore.overrides.baseImage === 'string'" class="flex items-center gap-3">
           <span class="text-gray-500 w-28 shrink-0">背景色</span>
           <span class="inline-flex items-center gap-2">
             <span
@@ -119,7 +119,7 @@ function reset() {
           <dd class="flex items-center gap-2">
             <span
               class="w-4 h-4 rounded-sm border border-gray-300"
-              :style="compositeStore.systemDefault.baseImage.startsWith('#')
+              :style="typeof compositeStore.systemDefault.baseImage === 'string' && compositeStore.systemDefault.baseImage.startsWith('#')
                 ? { background: compositeStore.systemDefault.baseImage }
                 : { background: 'transparent' }"
             />

--- a/frontend/src/components/settings/DefaultsTab.vue
+++ b/frontend/src/components/settings/DefaultsTab.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useCompositeDefaultsStore } from '@/stores/compositeDefaults'
+import { useUserDefaultsStore } from '@/stores/userDefaults'
+import type { Preset } from '@/stores/compositeDefaults'
+
+const compositeStore = useCompositeDefaultsStore()
+const userStore = useUserDefaultsStore()
+
+onMounted(async () => {
+  if (!compositeStore.isLoaded) {
+    await compositeStore.loadDefaults()
+  }
+})
+
+function applyPreset(preset: Preset) {
+  userStore.applyPreset(preset)
+}
+
+function reset() {
+  userStore.reset()
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+
+    <!-- プリセット一覧 -->
+    <section class="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+      <h2 class="text-sm font-medium text-gray-700 mb-1">プリセット</h2>
+      <p class="text-xs text-gray-500 mb-4">
+        典型的な配置パターンを適用すると、背景色と不透明度のデフォルト値が更新されます。
+      </p>
+
+      <div v-if="!compositeStore.isLoaded" class="text-sm text-gray-400">読み込み中...</div>
+
+      <div v-else-if="Object.keys(compositeStore.presets).length === 0" class="text-sm text-gray-400">
+        プリセットが定義されていません。
+      </div>
+
+      <div v-else class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div
+          v-for="(preset, name) in compositeStore.presets"
+          :key="name"
+          class="rounded-lg border border-gray-200 p-4 flex flex-col gap-3 bg-gray-50"
+        >
+          <div class="flex-1">
+            <h3 class="text-sm font-semibold text-gray-800 capitalize">{{ name }}</h3>
+            <p class="text-xs text-gray-500 mt-1">{{ preset.description }}</p>
+            <div class="mt-2 flex items-center gap-2 text-xs text-gray-600">
+              <span class="inline-flex items-center gap-1">
+                <span
+                  class="w-3 h-3 rounded-sm border border-gray-300 inline-block"
+                  :style="preset.baseImage.startsWith('#') ? { background: preset.baseImage } : { background: 'transparent' }"
+                />
+                {{ preset.baseImage === 'transparent' ? '透明' : preset.baseImage }}
+              </span>
+              <span>/ 不透明度 {{ preset.baseOpacity }}%</span>
+            </div>
+          </div>
+          <button
+            class="text-xs px-3 py-1.5 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors self-start"
+            @click="applyPreset(preset)"
+          >
+            適用
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- 現在のユーザー上書き -->
+    <section class="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+      <div class="flex items-center justify-between mb-3">
+        <div>
+          <h2 class="text-sm font-medium text-gray-700">現在のユーザー上書き</h2>
+          <p class="text-xs text-gray-500 mt-0.5">localStorage に保存されたデフォルト上書き値</p>
+        </div>
+        <button
+          v-if="userStore.hasOverrides"
+          class="text-xs px-3 py-1.5 bg-gray-100 text-gray-600 rounded hover:bg-gray-200 transition-colors"
+          @click="reset"
+        >
+          リセット
+        </button>
+      </div>
+
+      <div v-if="!userStore.hasOverrides" class="text-sm text-gray-400">
+        上書き設定なし（システムデフォルトを使用中）
+      </div>
+      <div v-else class="space-y-2 text-sm">
+        <div v-if="userStore.overrides.baseImage !== undefined" class="flex items-center gap-3">
+          <span class="text-gray-500 w-28 shrink-0">背景色</span>
+          <span class="inline-flex items-center gap-2">
+            <span
+              class="w-4 h-4 rounded-sm border border-gray-300"
+              :style="userStore.overrides.baseImage.startsWith('#')
+                ? { background: userStore.overrides.baseImage }
+                : { background: 'transparent' }"
+            />
+            <span class="font-mono text-gray-800">{{ userStore.overrides.baseImage }}</span>
+          </span>
+        </div>
+        <div v-if="userStore.overrides.baseOpacity !== undefined" class="flex items-center gap-3">
+          <span class="text-gray-500 w-28 shrink-0">不透明度</span>
+          <span class="font-mono text-gray-800">{{ userStore.overrides.baseOpacity }}%</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- システムデフォルト（読み取り専用） -->
+    <section class="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+      <h2 class="text-sm font-medium text-gray-700 mb-1">システムデフォルト</h2>
+      <p class="text-xs text-gray-500 mb-3">composite-default.json の system_default 値（読み取り専用）</p>
+
+      <div v-if="!compositeStore.systemDefault" class="text-sm text-gray-400">読み込み中...</div>
+      <dl v-else class="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">背景色</dt>
+          <dd class="flex items-center gap-2">
+            <span
+              class="w-4 h-4 rounded-sm border border-gray-300"
+              :style="compositeStore.systemDefault.baseImage.startsWith('#')
+                ? { background: compositeStore.systemDefault.baseImage }
+                : { background: 'transparent' }"
+            />
+            <span class="font-mono text-gray-800">{{ compositeStore.systemDefault.baseImage }}</span>
+          </dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">不透明度</dt>
+          <dd class="font-mono text-gray-800">{{ compositeStore.systemDefault.baseOpacity }}%</dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">キャンバス</dt>
+          <dd class="font-mono text-gray-800">
+            {{ compositeStore.systemDefault.canvas.width }}×{{ compositeStore.systemDefault.canvas.height }}
+          </dd>
+        </div>
+        <div class="flex items-center gap-2">
+          <dt class="text-gray-500 w-28 shrink-0">動画形式</dt>
+          <dd class="font-mono text-gray-800">
+            {{ compositeStore.systemDefault.video.format }} / {{ compositeStore.systemDefault.video.duration }}秒
+          </dd>
+        </div>
+      </dl>
+    </section>
+
+  </div>
+</template>

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -29,6 +29,15 @@
       >
         ルール（System Prompt）
       </button>
+      <button
+        class="px-4 py-2 text-sm font-medium transition-colors"
+        :class="activeTab === 'defaults'
+          ? 'text-blue-600 border-b-2 border-blue-500'
+          : 'text-gray-500 hover:text-gray-700'"
+        @click="activeTab = 'defaults'"
+      >
+        デフォルト
+      </button>
     </div>
 
     <!-- モデル選択タブ -->
@@ -107,6 +116,11 @@
         <PromptPreview />
       </div>
     </template>
+
+    <!-- デフォルト/プリセットタブ -->
+    <section v-else-if="activeTab === 'defaults'">
+      <DefaultsTab />
+    </section>
   </div>
 </template>
 
@@ -118,9 +132,10 @@ import { useChatAgent } from '@/composables/useChatAgent'
 import RuleList from '@/components/settings/RuleList.vue'
 import RuleEditor from '@/components/settings/RuleEditor.vue'
 import PromptPreview from '@/components/settings/PromptPreview.vue'
+import DefaultsTab from '@/components/settings/DefaultsTab.vue'
 import { useRulesStore } from '@/stores/rules'
 
-const activeTab = ref<'model' | 'rules'>('model')
+const activeTab = ref<'model' | 'rules' | 'defaults'>('model')
 
 const rulesStore = useRulesStore()
 const isCreatingRule = ref(false)

--- a/frontend/src/stores/__tests__/userDefaults.test.ts
+++ b/frontend/src/stores/__tests__/userDefaults.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useUserDefaultsStore } from '@/stores/userDefaults'
+import type { Preset } from '@/stores/compositeDefaults'
+
+const SAMPLE_PRESET: Preset = {
+  description: 'ライブ配信用',
+  baseImage: '#000000',
+  baseOpacity: 100,
+  image_placement: { image1: { x: 760, y: 290, width: 400, height: 400 } },
+  text_overlays: {
+    text1: { text: 'LIVE', position: '1800,80', font_size: 56, font_color: '#FF0000', bg_color: null },
+  },
+}
+
+describe('useUserDefaultsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('初期状態では overrides は空オブジェクト', () => {
+    const store = useUserDefaultsStore()
+    expect(store.overrides).toEqual({})
+    expect(store.hasOverrides).toBe(false)
+  })
+
+  it('applyPreset で baseImage/baseOpacity を localStorage に保存する', () => {
+    const store = useUserDefaultsStore()
+    store.applyPreset(SAMPLE_PRESET)
+    expect(store.overrides.baseImage).toBe('#000000')
+    expect(store.overrides.baseOpacity).toBe(100)
+    expect(store.hasOverrides).toBe(true)
+    const saved = JSON.parse(localStorage.getItem('composite-user-defaults') ?? '{}')
+    expect(saved.baseImage).toBe('#000000')
+  })
+
+  it('reset() で overrides をクリアし localStorage を削除する', () => {
+    const store = useUserDefaultsStore()
+    store.applyPreset(SAMPLE_PRESET)
+    store.reset()
+    expect(store.overrides).toEqual({})
+    expect(store.hasOverrides).toBe(false)
+    expect(localStorage.getItem('composite-user-defaults')).toBeNull()
+  })
+
+  it('localStorage に保存済み値があれば初期化時に復元する', () => {
+    localStorage.setItem('composite-user-defaults', JSON.stringify({ baseImage: '#FFFFFF', baseOpacity: 80 }))
+    const store = useUserDefaultsStore()
+    expect(store.overrides.baseImage).toBe('#FFFFFF')
+    expect(store.overrides.baseOpacity).toBe(80)
+  })
+
+  it('localStorage が壊れていてもエラーにならず空オブジェクトを返す', () => {
+    localStorage.setItem('composite-user-defaults', 'invalid json{')
+    const store = useUserDefaultsStore()
+    expect(store.overrides).toEqual({})
+  })
+})

--- a/frontend/src/stores/compositeDefaults.ts
+++ b/frontend/src/stores/compositeDefaults.ts
@@ -109,7 +109,16 @@ export const useCompositeDefaultsStore = defineStore('compositeDefaults', () => 
     try {
       const res = await fetch(url, { cache: 'no-cache' })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      defaults.value = (await res.json()) as CompositeDefaults
+      const data = (await res.json()) as CompositeDefaults
+      if (data.presets && typeof data.presets === 'object') {
+        for (const [key, preset] of Object.entries(data.presets)) {
+          if (typeof preset.baseImage !== 'string') {
+            console.warn(`[compositeDefaults] presets.${key}.baseImage が string でないため除外`)
+            delete data.presets[key]
+          }
+        }
+      }
+      defaults.value = data
     } catch (e) {
       console.warn('[compositeDefaults] 読み込み失敗、フォールバック使用:', e)
       defaults.value = HARDCODED_FALLBACK

--- a/frontend/src/stores/compositeDefaults.ts
+++ b/frontend/src/stores/compositeDefaults.ts
@@ -26,6 +26,23 @@ export type ImageMode = 'single' | 'double' | 'triple'
 export type ImageKey = 'image1' | 'image2' | 'image3'
 export type TextKey = 'text1' | 'text2' | 'text3'
 
+export interface PresetTextOverlay {
+  text: string
+  position: string
+  font_size: number
+  font_color: string
+  bg_color: string | null
+  bg_opacity?: number
+}
+
+export interface Preset {
+  description: string
+  baseImage: string
+  baseOpacity: number
+  image_placement: Partial<Record<ImageKey, ImagePosition>>
+  text_overlays: Record<string, PresetTextOverlay>
+}
+
 export interface SystemDefault {
   canvas: { width: number; height: number }
   baseImage: string
@@ -46,7 +63,7 @@ export interface SystemDefault {
 export interface CompositeDefaults {
   version: string
   system_default: SystemDefault
-  presets: Record<string, unknown>
+  presets: Record<string, Preset>
 }
 
 // design §6.9: フォールバック値。baseImage は transparent を維持してリスク最小化
@@ -83,6 +100,7 @@ export const useCompositeDefaultsStore = defineStore('compositeDefaults', () => 
   const isLoaded = ref(false)
 
   const systemDefault = computed(() => defaults.value?.system_default ?? null)
+  const presets = computed(() => defaults.value?.presets ?? {})
 
   async function loadDefaults(): Promise<void> {
     if (isLoaded.value) return
@@ -124,6 +142,7 @@ export const useCompositeDefaultsStore = defineStore('compositeDefaults', () => 
     defaults,
     isLoaded,
     systemDefault,
+    presets,
     loadDefaults,
     determineImageMode,
     getImageDefault,

--- a/frontend/src/stores/userDefaults.ts
+++ b/frontend/src/stores/userDefaults.ts
@@ -1,0 +1,42 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import type { Preset } from './compositeDefaults'
+
+const STORAGE_KEY = 'composite-user-defaults'
+
+export interface UserDefaults {
+  baseImage?: string
+  baseOpacity?: number
+}
+
+function loadFromStorage(): UserDefaults {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as UserDefaults) : {}
+  } catch {
+    return {}
+  }
+}
+
+export const useUserDefaultsStore = defineStore('userDefaults', () => {
+  const overrides = ref<UserDefaults>(loadFromStorage())
+
+  const hasOverrides = computed(
+    () => overrides.value.baseImage !== undefined || overrides.value.baseOpacity !== undefined,
+  )
+
+  function applyPreset(preset: Preset): void {
+    overrides.value = {
+      baseImage: preset.baseImage,
+      baseOpacity: preset.baseOpacity,
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides.value))
+  }
+
+  function reset(): void {
+    overrides.value = {}
+    localStorage.removeItem(STORAGE_KEY)
+  }
+
+  return { overrides, hasOverrides, applyPreset, reset }
+})

--- a/frontend/src/stores/userDefaults.ts
+++ b/frontend/src/stores/userDefaults.ts
@@ -12,7 +12,13 @@ export interface UserDefaults {
 function loadFromStorage(): UserDefaults {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    return raw ? (JSON.parse(raw) as UserDefaults) : {}
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return {}
+    return {
+      ...(typeof parsed.baseImage === 'string' ? { baseImage: parsed.baseImage } : {}),
+      ...(typeof parsed.baseOpacity === 'number' ? { baseOpacity: parsed.baseOpacity } : {}),
+    }
   } catch {
     return {}
   }


### PR DESCRIPTION
## 概要

Issue #59 Phase 2 — SettingsPage に「デフォルト」タブを追加し、プリセット一覧表示・ユーザー個別上書き（localStorage）・リセット機能を実装する。

Phase 1（backend / agent_tools の preset 機能）は PR #101 でマージ済み。本 PR はフロントエンドのみの変更。

## 変更内容

- `stores/compositeDefaults.ts`: `Preset` / `PresetTextOverlay` 型を追加、`presets` ゲッターを公開
- `stores/userDefaults.ts`: 新設。localStorage (`composite-user-defaults`) でユーザー上書き値（baseImage / baseOpacity）を管理。`applyPreset()` / `reset()` を提供
- `App.vue`: `applyCompositeDefaults()` の直後に `applyUserOverrides()` を実行し、`system_default < userDefaults < UI明示指定` の優先チェーンを実現
- `components/settings/DefaultsTab.vue`: 新規作成。プリセットカード一覧（live/promo/subtitle）+ 「適用」ボタン、現在のユーザー上書き表示 + 「リセット」ボタン、システムデフォルト読み取り専用表示
- `pages/SettingsPage.vue`: 3番目のタブ「デフォルト」を追加
- `.kiro/specs/image-composition/tasks.md`: Phase 2 タスク（22〜26）を追記・完了マーク

## 設計判断

- `userDefaults` のスコープは `baseImage` / `baseOpacity` のみに限定。`image_placement` の上書きは Agent Tools（チャット経由）の責務として UI には出さない
- プリセット一覧は読み取り専用（編集UIは将来検討）

## テスト計画

- [x] `stores/__tests__/userDefaults.test.ts` 新規作成（5件: 初期状態 / applyPreset / reset / localStorage復元 / 不正JSON時のフォールバック）
- [x] TypeScript 型チェック（`tsc --noEmit`）で新規エラーなしを確認
- [ ] ローカル vitest 実行は本環境（Raspberry Pi ARM）で `Illegal instruction` のため未実行 → CI での実行結果を確認してください
- [ ] dev環境デプロイ後、`/chat/settings` でデフォルトタブの表示・プリセット適用・リセットを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)